### PR TITLE
[WIP] Sign/verify iOS implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Implementation is in PKCS1
 ## Status
 
 Android: Generation, Encryption, Decryption
-iOS: Generation, Encryption, Decryption
+iOS: Generation, Encryption, Decryption, Sign
 
 *Need to check cross platform encrypt/decrypt
 
@@ -36,12 +36,16 @@ RSA.generate()
   .then(keys => {
     console.log(keys.private) // the private key
     console.log(keys.public) // the public key
-    RNRSA.encrypt('1234', keys.public)
+    RSA.encrypt('1234', keys.public)
       .then(encodedMessage => {
-        RNRSA.decrypt(encodedMessage, keys.private)
+        RSA.decrypt(encodedMessage, keys.private)
           .then(message => {
             console.log(message)
           })
+        })
+        RSA.sign(secret, keys.private)
+          .then(signature => {
+            console.log(signature);
         })
     })
 
@@ -53,18 +57,22 @@ let secret = "secret message";
 RNRSAKeychain.generate(keyTag)
   .then(keys => {
     console.log(keys.public);
-
     console.log(secret);
 
-    RSA.encrypt(secret, keyTag)
+    RNRSAKeychain.encrypt(secret, keyTag)
       .then(encodedMessage => {
         console.log(encodedMessage);
 
-        RSA.decrypt(encodedMessage, keyTag)
+        RNRSAKeychain.decrypt(encodedMessage, keyTag)
           .then(message => {
             console.log(message);
           })
         })
+
+        RNRSAKeychain.sign(secret, keyTag)
+          .then(signature => {
+            console.log(signature);
+          })
     });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # react-native-rsa-native
 
-A native implementation of RSA key generation and encryption/decryption.
+A native implementation of RSA key generation and encryption/decryption, sign/verify.
 Implementation is in PKCS1
 
 ## Status
 
 Android: Generation, Encryption, Decryption
-iOS: Generation, Encryption, Decryption, Sign
+iOS: Generation, Encryption, Decryption, Sign, Verify
 
 *Need to check cross platform encrypt/decrypt
 
@@ -40,14 +40,20 @@ RSA.generate()
       .then(encodedMessage => {
         RSA.decrypt(encodedMessage, keys.private)
           .then(message => {
-            console.log(message)
+            console.log(message);
           })
         })
-        RSA.sign(secret, keys.private)
-          .then(signature => {
-            console.log(signature);
+
+    RSA.sign(secret, keys.private)
+      .then(signature => {
+        console.log(signature);
+
+        RSA.verify(signature, secret, keys.public)
+          .then(valid => {
+            console.log(valid);
+          })
         })
-    })
+  })
 
 // Example utilizing the keychain for private key secure storage
 
@@ -69,11 +75,16 @@ RNRSAKeychain.generate(keyTag)
           })
         })
 
-        RNRSAKeychain.sign(secret, keyTag)
-          .then(signature => {
-            console.log(signature);
+    RNRSAKeychain.sign(secret, keyTag)
+      .then(signature => {
+        console.log(signature);
+
+        RNRSAKeychain.verify(signature, secret, keyTag)
+          .then(valid => {
+            console.log(valid);
           })
-    });
+        })
+  });
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In your React Native Xcode project, right click on your project and go 'Add File
 
 ```
 
-import RSA, {RNRSAKeychain} from 'react-native-rsa-native';
+import {RSA, RSAKeychain} from 'react-native-rsa-native';
 
 RSA.generate()
   .then(keys => {
@@ -60,26 +60,26 @@ RSA.generate()
 let keyTag = 'com.domain.mykey';
 let secret = "secret message";
 
-RNRSAKeychain.generate(keyTag)
+RSAKeychain.generate(keyTag)
   .then(keys => {
     console.log(keys.public);
     console.log(secret);
 
-    RNRSAKeychain.encrypt(secret, keyTag)
+    RSAKeychain.encrypt(secret, keyTag)
       .then(encodedMessage => {
         console.log(encodedMessage);
 
-        RNRSAKeychain.decrypt(encodedMessage, keyTag)
+        RSAKeychain.decrypt(encodedMessage, keyTag)
           .then(message => {
             console.log(message);
           })
         })
 
-    RNRSAKeychain.sign(secret, keyTag)
+    RSAKeychain.sign(secret, keyTag)
       .then(signature => {
         console.log(signature);
 
-        RNRSAKeychain.verify(signature, secret, keyTag)
+        RSAKeychain.verify(signature, secret, keyTag)
           .then(valid => {
             console.log(valid);
           })

--- a/android/src/main/java/com/RNRSA/RNRSAModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAModule.java
@@ -71,4 +71,35 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
       }
   }
 
+    @ReactMethod
+    public void sign(String message, String privateKeyString, Promise promise)  {
+
+        try {
+            RSA rsa = new RSA();
+            rsa.setPrivateKey(privateKeyString);
+            String signature = rsa.sign(message);
+            promise.resolve(signature);
+
+        } catch(Exception e) {
+            promise.reject("Error", e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void verify(String signature, String message, String publicKeyString, Promise promise)  {
+
+        try {
+            RSA rsa = new RSA();
+            rsa.setPublicKey(publicKeyString);
+            boolean verified = rsa.verify(signature, message);
+            promise.resolve(verified);
+
+        } catch(Exception e) {
+            promise.reject("Error", e.getMessage());
+        }
+    }
+
+
+
+
 }

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -13,6 +13,8 @@ import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.InvalidKeyException;
+import java.security.Signature;
+import java.security.SignatureException;
 import java.security.spec.X509EncodedKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.RSAPrivateKeySpec;
@@ -90,6 +92,25 @@ public class RSA {
         message = new String(data, UTF_8);
 
         return message;
+    }
+
+    public String sign(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+        Signature privateSignature = Signature.getInstance("SHA512withRSA");
+        privateSignature.initSign(this.privateKey);
+        privateSignature.update(message.getBytes(UTF_8));
+        byte[] signature = privateSignature.sign();
+
+        return Base64.encodeToString(signature, Base64.DEFAULT);
+    }
+
+    public boolean verify(String signature, String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+        Signature publicSignature = Signature.getInstance("SHA512withRSA");
+        publicSignature.initVerify(this.publicKey);
+        publicSignature.update(message.getBytes(UTF_8));
+
+        byte[] signatureBytes = Base64.decode(signature, Base64.DEFAULT);
+
+        return publicSignature.verify(signatureBytes);
     }
 
     private String dataToPem(String header, byte[] keyData) throws IOException {

--- a/example/App/App.js
+++ b/example/App/App.js
@@ -1,42 +1,62 @@
 import React, { Component } from 'react'
 import { View, Text } from 'react-native'
 
-import RSA, {RNRSAKeychain} from 'react-native-rsa-native';
+import {RSA, RSAKeychain} from 'react-native-rsa-native';
 
 RSA.generate()
   .then(keys => {
     console.log(keys.private) // the private key
     console.log(keys.public) // the public key
-    RNRSA.encrypt('1234', keys.public)
+    RSA.encrypt('1234', keys.public)
       .then(encodedMessage => {
-        RNRSA.decrypt(encodedMessage, keys.private)
-          .then(message => {
-            console.log(message)
-          })
-        })
-    })
-
-
-let keyTag = 'com.domain.mykey';
-let secret = "secret message";
-
-RNRSAKeychain.generate(keyTag)
-  .then(keys => {
-    console.log(keys.public);
-
-    console.log(secret);
-
-    RSA.encrypt(secret, keyTag)
-      .then(encodedMessage => {
-        console.log(encodedMessage);
-
-        RSA.decrypt(encodedMessage, keyTag)
+        RSA.decrypt(encodedMessage, keys.private)
           .then(message => {
             console.log(message);
           })
         })
-    });
-    
+
+    RSA.sign(secret, keys.private)
+      .then(signature => {
+        console.log('signature', signature);
+
+        RSA.verify(signature, secret, keys.public)
+          .then(valid => {
+            console.log('verified', valid);
+          })
+        })
+  })
+
+// Example utilizing the keychain for private key secure storage
+
+let keyTag = 'com.domain.mykey';
+let secret = "secret message";
+
+RSAKeychain.generate(keyTag)
+  .then(keys => {
+    console.log(keys.public);
+    console.log(secret);
+
+    RSAKeychain.encrypt(secret, keyTag)
+      .then(encodedMessage => {
+        console.log(encodedMessage);
+
+        RSAKeychain.decrypt(encodedMessage, keyTag)
+          .then(message => {
+            console.log(message);
+          })
+        })
+
+    RSAKeychain.sign(secret, keyTag)
+      .then(signature => {
+        console.log('signature', signature);
+
+        RSAKeychain.verify(signature, secret, keyTag)
+          .then(valid => {
+            console.log('verified', valid);
+          })
+        })
+  });
+
 class App extends Component {
   componentWillMount () {
   

--- a/index.js
+++ b/index.js
@@ -4,6 +4,6 @@ import { NativeModules } from 'react-native';
 const { RNRSAKeychain } = NativeModules;
 const { RNRSA } = NativeModules;
 
-export { RNRSAKeychain };
+export { RNRSAKeychain as RSAKeychain, RNRSA as RSA };
 
 export default RNRSA;

--- a/index.js
+++ b/index.js
@@ -4,6 +4,6 @@ import { NativeModules } from 'react-native';
 const { RNRSAKeychain } = NativeModules;
 const { RNRSA } = NativeModules;
 
-export { RNRSAKeychain as RSAKeychain, RNRSA as RSA };
+export { RNRSAKeychain, RNRSAKeychain as RSAKeychain, RNRSA, RNRSA as RSA };
 
 export default RNRSA;

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -38,6 +38,14 @@ RCT_EXPORT_METHOD(decrypt:(NSString *)encodedMessage withKey:(NSString *)key res
     resolve(message);
 }
 
+RCT_EXPORT_METHOD(sign:(NSString *)message withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  RSANative *rsa = [[RSANative alloc] init];
+  rsa.privateKey = key;
+  NSString *signature = [rsa sign:message];
+  resolve(signature);
+}
+
 @end
 
 @implementation RNRSAKeychain
@@ -70,6 +78,13 @@ RCT_EXPORT_METHOD(decrypt:(NSString *)encodedMessage withKeyTag:(NSString *)keyT
     RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
     NSString *message = [rsa decrypt:encodedMessage];
     resolve(message);
+}
+
+RCT_EXPORT_METHOD(sign:(NSString *)message withKeyTag:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
+  NSString *signature = [rsa sign:message];
+  resolve(signature);
 }
 
 @end

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -40,10 +40,18 @@ RCT_EXPORT_METHOD(decrypt:(NSString *)encodedMessage withKey:(NSString *)key res
 
 RCT_EXPORT_METHOD(sign:(NSString *)message withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-  RSANative *rsa = [[RSANative alloc] init];
-  rsa.privateKey = key;
-  NSString *signature = [rsa sign:message];
-  resolve(signature);
+    RSANative *rsa = [[RSANative alloc] init];
+    rsa.privateKey = key;
+    NSString *signature = [rsa sign:message];
+    resolve(signature);
+}
+
+RCT_EXPORT_METHOD(verify:(NSString *)signature withMessage:(NSString *)message andKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    RSANative *rsa = [[RSANative alloc] init];
+    rsa.publicKey = key;
+    BOOL valid = [rsa verify:signature withMessage:message];
+    resolve(@(valid));
 }
 
 @end
@@ -82,9 +90,16 @@ RCT_EXPORT_METHOD(decrypt:(NSString *)encodedMessage withKeyTag:(NSString *)keyT
 
 RCT_EXPORT_METHOD(sign:(NSString *)message withKeyTag:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-  RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-  NSString *signature = [rsa sign:message];
-  resolve(signature);
+    RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
+    NSString *signature = [rsa sign:message];
+    resolve(signature);
+}
+
+RCT_EXPORT_METHOD(verify:(NSString *)signature withMessage:(NSString *)message andKeyTag:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
+    BOOL valid = [rsa verify:signature withMessage:message];
+    resolve(@(valid));
 }
 
 @end

--- a/ios/RSAFormatter.h
+++ b/ios/RSAFormatter.h
@@ -10,8 +10,8 @@
 
 @interface RSAFormatter : NSObject
 
-+ (NSString *) PEMFormattedPublicKey:(NSData *)publicKeyData;
-+ (NSString *) PEMFormattedPrivateKey:(NSData *)privateKeyData;
-+ (NSString *) stripHeaders: (NSString *)pemString;
++ (NSString *)PEMFormattedPublicKey:(NSData *)publicKeyData;
++ (NSString *)PEMFormattedPrivateKey:(NSData *)privateKeyData;
++ (NSString *)stripHeaders:(NSString *)pemString;
 
 @end

--- a/ios/RSAFormatter.m
+++ b/ios/RSAFormatter.m
@@ -13,22 +13,19 @@
 static NSString *publicTag = @"RSA PUBLIC";
 static NSString *privateTag = @"RSA PRIVATE";
 
-+ (NSString *)PEMFormattedPublicKey:(NSData *)publicKeyData
-{
++ (NSString *)PEMFormattedPublicKey:(NSData *)publicKeyData {
     NSMutableData * encodedKey = [[NSMutableData alloc] init];
     [encodedKey appendData:publicKeyData];
     return [self pemFormat:encodedKey tag:publicTag];
 }
 
-+ (NSString *)PEMFormattedPrivateKey:(NSData *)privateKeyData
-{
++ (NSString *)PEMFormattedPrivateKey:(NSData *)privateKeyData {
     NSMutableData * encodedKey = [[NSMutableData alloc] init];
     [encodedKey appendData:privateKeyData];
     return [self pemFormat:encodedKey tag:privateTag];
 }
 
-+(NSString *) pemFormat:(NSData *)encodedKey tag:(NSString *)tag
-{
++ (NSString *)pemFormat:(NSData *)encodedKey tag:(NSString *)tag {
     return [NSString stringWithFormat:@"%@\n%@\n%@",
             [self headerForTag:tag],
             [encodedKey base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength],
@@ -36,18 +33,15 @@ static NSString *privateTag = @"RSA PRIVATE";
             ];
 }
 
-+ (NSString *) headerForTag:(NSString *)tag
-{
++ (NSString *)headerForTag:(NSString *)tag {
     return [NSString stringWithFormat:@"-----BEGIN %@ KEY-----", tag ];
 }
 
-+ (NSString *) footerForTag:(NSString *)tag
-{
++ (NSString *)footerForTag:(NSString *)tag {
     return [NSString stringWithFormat:@"-----END %@ KEY-----", tag];
 }
 
-+ (NSString *) stripHeaders: (NSString *)pemString
-{
++ (NSString *)stripHeaders:(NSString *)pemString {
     NSRange spos;
     NSRange epos;
     spos = [pemString rangeOfString:[self headerForTag:privateTag]];

--- a/ios/RSANative.h
+++ b/ios/RSANative.h
@@ -23,4 +23,6 @@
 - (NSString *)encrypt:(NSString *)message;
 - (NSString *)decrypt:(NSString *)encodedMessage;
 
+- (NSString *)sign:(NSString *)message;
+
 @end

--- a/ios/RSANative.h
+++ b/ios/RSANative.h
@@ -24,5 +24,6 @@
 - (NSString *)decrypt:(NSString *)encodedMessage;
 
 - (NSString *)sign:(NSString *)message;
+- (BOOL)verify:(NSString *)signature withMessage:(NSString *)message;
 
 @end


### PR DESCRIPTION
Hi @amitaymolko 

Hope all is going well mate.

Here's the iOS implementation methods required to create and verify digital signatures of content for both the keychain and in-memory store modules.

Please have a look and let me know if you're happy with the implementation. Have also updated the README with some examples - happy to adjust into the API you're considering as mentioned in the previous PR now or later.

Keen to get the Android side sorted so we can have parity across the platforms - not too sure where to start but let me know if you'd like me to look into that?

Hear from you soon then - Cheers.