### PR TITLE
Fix exceptions raised when generating keypairs on Pixel API 23 devices

### DIFF
--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -203,7 +203,7 @@ public class RSA {
     }
 
     public void generate(String keyTag) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance(ALGORITHM);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(ALGORITHM, "AndroidKeyStore");
         kpg.initialize(new KeyGenParameterSpec.Builder(
                 keyTag,
                 PURPOSE_ENCRYPT | PURPOSE_DECRYPT | PURPOSE_SIGN | PURPOSE_VERIFY


### PR DESCRIPTION
Closes #12 

Adds extra parameter to KeyPairGenerator.getInstance for AndroidKeyStore, which fixes Pixel API 23 devices raising a 'Only RSAKeyGenParameterSpec supported' exception during key generation.

Cheers.