### PR TITLE
Include throwable error for KeyPairGenerator.getInstance(x,x)

### DIFF
--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -15,6 +15,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.security.NoSuchProviderException;
 import java.security.PublicKey;
 import java.security.PrivateKey;
 import java.security.KeyFactory;
@@ -212,7 +213,7 @@ public class RSA {
         this.privateKey = keyPair.getPrivate();
     }
 
-    public void generate(String keyTag) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+    public void generate(String keyTag) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(ALGORITHM, "AndroidKeyStore");
         kpg.initialize(new KeyGenParameterSpec.Builder(
                 keyTag,


### PR DESCRIPTION
Slight fix required in addition to: https://github.com/amitaymolko/react-native-rsa-native/issues/12

When building, the additional argument for `KeyPairGenerator.getInstance(x,x)` means a new exception can be thrown (`NoSuchProviderException`) resulting in error:

`RSA.java:216: error: unreported exception NoSuchProviderException; must be caught or declared to be thrown`

Made the modifications on my local project and all is well, and issue #12 is fixed too.