### PR TITLE
add encrypt64, decrypt64

### DIFF
--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -67,6 +67,18 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
       }
   }
 
+  @ReactMethod
+  public void encrypt64(String message, String keyTag, Promise promise)  {
+
+      try {
+          RSA rsa = new RSA(keyTag);
+          String encodedMessage = rsa.encrypt64(message);
+          promise.resolve(encodedMessage);
+      } catch(Exception e) {
+          promise.reject("Error", e.getMessage());
+      }
+  }
+
 
   @ReactMethod
   public void decrypt(String encodedMessage, String keyTag, Promise promise)  {
@@ -74,6 +86,19 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
       try {
           RSA rsa = new RSA(keyTag);
           String message = rsa.decrypt(encodedMessage);
+          promise.resolve(message);
+
+      } catch(Exception e) {
+          promise.reject("Error", e.getMessage());
+      }
+  }
+
+  @ReactMethod
+  public void decrypt64(String encodedMessage, String keyTag, Promise promise)  {
+
+      try {
+          RSA rsa = new RSA(keyTag);
+          String message = rsa.decrypt64(encodedMessage);
           promise.resolve(message);
 
       } catch(Exception e) {

--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -120,6 +120,19 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void sign64(String message, String keyTag, Promise promise)  {
+
+        try {
+            RSA rsa = new RSA(keyTag);
+            String signature = rsa.sign64(message);
+            promise.resolve(signature);
+
+        } catch(Exception e) {
+            promise.reject("Error", e.getMessage());
+        }
+    }
+
+    @ReactMethod
     public void verify(String signature, String message, String keyTag, Promise promise)  {
 
         try {
@@ -132,6 +145,18 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void verify64(String signature, String message, String keyTag, Promise promise)  {
+
+        try {
+            RSA rsa = new RSA(keyTag);
+            boolean verified = rsa.verify64(signature, message);
+            promise.resolve(verified);
+
+        } catch(Exception e) {
+            promise.reject("Error", e.getMessage());
+        }
+    }
 
 
 

--- a/android/src/main/java/com/RNRSA/RNRSAModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAModule.java
@@ -113,6 +113,20 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void sign64(String message, String privateKeyString, Promise promise)  {
+
+        try {
+            RSA rsa = new RSA();
+            rsa.setPrivateKey(privateKeyString);
+            String signature = rsa.sign64(message);
+            promise.resolve(signature);
+
+        } catch(Exception e) {
+            promise.reject("Error", e.getMessage());
+        }
+    }
+
+    @ReactMethod
     public void verify(String signature, String message, String publicKeyString, Promise promise)  {
 
         try {
@@ -126,6 +140,19 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void verify64(String signature, String message, String publicKeyString, Promise promise)  {
+
+        try {
+            RSA rsa = new RSA();
+            rsa.setPublicKey(publicKeyString);
+            boolean verified = rsa.verify64(signature, message);
+            promise.resolve(verified);
+
+        } catch(Exception e) {
+            promise.reject("Error", e.getMessage());
+        }
+    }
 
 
 

--- a/android/src/main/java/com/RNRSA/RNRSAModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAModule.java
@@ -56,6 +56,19 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
       }
   }
 
+  @ReactMethod
+  public void encrypt64(String message, String publicKeyString, Promise promise)  {
+
+      try {
+          RSA rsa = new RSA();
+          rsa.setPublicKey(publicKeyString);
+          String encodedMessage = rsa.encrypt64(message);
+          promise.resolve(encodedMessage);
+      } catch(Exception e) {
+          promise.reject("Error", e.getMessage());
+      }
+  }
+
 
   @ReactMethod
   public void decrypt(String encodedMessage, String privateKeyString, Promise promise)  {
@@ -64,6 +77,20 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
           RSA rsa = new RSA();
           rsa.setPrivateKey(privateKeyString);
           String message = rsa.decrypt(encodedMessage);
+          promise.resolve(message);
+
+      } catch(Exception e) {
+          promise.reject("Error", e.getMessage());
+      }
+  }
+
+  @ReactMethod
+  public void decrypt64(String encodedMessage, String privateKeyString, Promise promise)  {
+
+      try {
+          RSA rsa = new RSA();
+          rsa.setPrivateKey(privateKeyString);
+          String message = rsa.decrypt64(encodedMessage);
           promise.resolve(message);
 
       } catch(Exception e) {

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -111,7 +111,7 @@ public class RSA {
 
     // Base64 input
     public String encrypt64(String b64Message){
-        byte[] data = Base64.getDecoder().decode(b64Message);
+        byte[] data = Base64.decode(b64Message);
         byte[] cipherbytes = encrypt(data);
         return Base64.encodeToString(cipherbytes, Base64.DEFAULT);
     }

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -105,64 +105,89 @@ public class RSA {
         String encodedMessage = null;
         final Cipher cipher = Cipher.getInstance("RSA/NONE/PKCS1Padding");
         cipher.init(Cipher.ENCRYPT_MODE, this.publicKey);
-        byte[] cipherbytes = cipher.doFinal(data);
-        return cipherbytes;
+        byte[] cipherBytes = cipher.doFinal(data);
+        return cipherBytes;
     }
 
     // Base64 input
     public String encrypt64(String b64Message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         byte[] data = Base64.decode(b64Message, Base64.DEFAULT);
-        byte[] cipherbytes = encrypt(data);
-        return Base64.encodeToString(cipherbytes, Base64.DEFAULT);
+        byte[] cipherBytes = encrypt(data);
+        return Base64.encodeToString(cipherBytes, Base64.DEFAULT);
     }
 
     // UTF-8 input
     public String encrypt(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         byte[] data = message.getBytes(UTF_8);
-        byte[] cipherbytes = encrypt(data);
-        return new String(cipherbytes, UTF_8);
+        byte[] cipherBytes = encrypt(data);
+        return new String(cipherBytes, UTF_8);
     }
 
-    public byte[] decrypt(byte[] cipherbytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
+    public byte[] decrypt(byte[] cipherBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         String message = null;
         final Cipher cipher = Cipher.getInstance("RSA/NONE/PKCS1Padding");
         cipher.init(Cipher.DECRYPT_MODE, this.privateKey);
-        byte[] data = cipher.doFinal(cipherbytes);
+        byte[] data = cipher.doFinal(cipherBytes);
         return data;
     }
 
     // UTF-8 input
     public String decrypt(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
-        byte[] cipherbytes = message.getBytes(UTF_8);
-        byte[] data = decrypt(cipherbytes);
+        byte[] cipherBytes = message.getBytes(UTF_8);
+        byte[] data = decrypt(cipherBytes);
         return new String(data, UTF_8);
     }
 
     // Base64 input
     public String decrypt64(String b64message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
-        byte[] cipherbytes = Base64.decode(b64message, Base64.DEFAULT);
-        byte[] data = decrypt(cipherbytes);
+        byte[] cipherBytes = Base64.decode(b64message, Base64.DEFAULT);
+        byte[] data = decrypt(cipherBytes);
         return Base64.encodeToString(data, Base64.DEFAULT);
     }
 
-    public String sign(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+    public String sign(byte[] messageBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
         Signature privateSignature = Signature.getInstance("SHA512withRSA");
         privateSignature.initSign(this.privateKey);
-
-        privateSignature.update(message.getBytes(UTF_8));
+        privateSignature.update(messageBytes);
         byte[] signature = privateSignature.sign();
-
         return Base64.encodeToString(signature, Base64.DEFAULT);
     }
 
+    // b64 message
+    public String sign64(String b64message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+        byte[] messageBytes = Base64.decode(b64message, Base64.DEFAULT);
+        return sign(messageBytes);
+    }
+
+    //utf-8 message
+    public String sign(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+        byte[] messageBytes = message.getBytes(UTF_8);
+        return sign(messageBytes);
+    }
+
+    public boolean verify(byte[] signatureBytes, byte[] messageBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+        Signature publicSignature = Signature.getInstance("SHA512withRSA");
+        publicSignature.initVerify(this.publicKey);
+        publicSignature.update(messageBytes);
+        return publicSignature.verify(signatureBytes);
+    }
+
+    // b64 message
+    public boolean verify64(String signature, String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+        Signature publicSignature = Signature.getInstance("SHA512withRSA");
+        publicSignature.initVerify(this.publicKey);
+        byte[] messageBytes = Base64.decode(message, Base64.DEFAULT);
+        byte[] signatureBytes = Base64.decode(signature, Base64.DEFAULT);
+        return verify(signatureBytes, messageBytes);
+    }
+
+    // utf-8 message
     public boolean verify(String signature, String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
         Signature publicSignature = Signature.getInstance("SHA512withRSA");
         publicSignature.initVerify(this.publicKey);
-        publicSignature.update(message.getBytes(UTF_8));
-
+        byte[] messageBytes = message.getBytes(UTF_8));
         byte[] signatureBytes = Base64.decode(signature, Base64.DEFAULT);
-
-        return publicSignature.verify(signatureBytes);
+        return verify(signatureBytes, messageBytes);
     }
 
     private String dataToPem(String header, byte[] keyData) throws IOException {

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -99,27 +99,50 @@ public class RSA {
         this.privateKey = pkcs1ToPrivateKey(pkcs1PrivateKey);
     }
 
-    public String encrypt(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
+
+    // This function will be called by encrypt and encrypt64
+    private byte[] encrypt(byte[] data) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         String encodedMessage = null;
         final Cipher cipher = Cipher.getInstance("RSA/NONE/PKCS1Padding");
         cipher.init(Cipher.ENCRYPT_MODE, this.publicKey);
-        byte[] data = cipher.doFinal(message.getBytes(UTF_8));
-        encodedMessage = Base64.encodeToString(data, Base64.DEFAULT);
-
-        return encodedMessage;
+        byte[] cipherbytes = cipher.doFinal(data);
+        return cipherbytes;
     }
 
-    public String decrypt(String encodedMessage) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
+    // Base64 input
+    public String encrypt64(String b64Message){
+        byte[] data = Base64.getDecoder().decode(b64Message);
+        byte[] cipherbytes = encrypt(data)
+        return Base64.encodeToString(cipherbytes, Base64.DEFAULT);
+    }
+
+    // UTF-8 input
+    public String encrypt(String message) {
+        byte[] data = message.getBytes(UTF_8);
+        byte[] cipherbytes = encrypt(data)
+        return new String(cipherbytes, UTF_8)
+    }
+
+    public byte[] decrypt(byte[] cipherbytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         String message = null;
-        byte[] cipherText = Base64.decode(encodedMessage, Base64.DEFAULT);
         final Cipher cipher = Cipher.getInstance("RSA/NONE/PKCS1Padding");
         cipher.init(Cipher.DECRYPT_MODE, this.privateKey);
+        byte[] data = cipher.doFinal(cipherbytes);
+        return data;
+    }
 
-        byte[] data = cipher.doFinal(cipherText);
+    // UTF-8 input
+    public String decrypt(String message) {
+        byte[] cipherbytes = message.getBytes(UTF_8);
+        byte[] data = decrypt(cipherbytes)
+        return new String(data, UTF_8);
+    }
 
-        message = new String(data, UTF_8);
-
-        return message;
+    // Base64 input
+    public String decrypt64(String b64message) {
+        byte[] cipherbytes = Base64.decode(b64message, Base64.DEFAULT);
+        byte[] data = decrypt(cipherbytes)
+        return Base64.encodeToString(data, Base64.DEFAULT);
     }
 
     public String sign(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -185,7 +185,7 @@ public class RSA {
     public boolean verify(String signature, String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
         Signature publicSignature = Signature.getInstance("SHA512withRSA");
         publicSignature.initVerify(this.publicKey);
-        byte[] messageBytes = message.getBytes(UTF_8));
+        byte[] messageBytes = message.getBytes(UTF_8);
         byte[] signatureBytes = Base64.decode(signature, Base64.DEFAULT);
         return verify(signatureBytes, messageBytes);
     }

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -111,7 +111,7 @@ public class RSA {
 
     // Base64 input
     public String encrypt64(String b64Message){
-        byte[] data = Base64.decode(b64Message);
+        byte[] data = Base64.decode(b64Message, Base64.DEFAULT);
         byte[] cipherbytes = encrypt(data);
         return Base64.encodeToString(cipherbytes, Base64.DEFAULT);
     }

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -112,15 +112,15 @@ public class RSA {
     // Base64 input
     public String encrypt64(String b64Message){
         byte[] data = Base64.getDecoder().decode(b64Message);
-        byte[] cipherbytes = encrypt(data)
+        byte[] cipherbytes = encrypt(data);
         return Base64.encodeToString(cipherbytes, Base64.DEFAULT);
     }
 
     // UTF-8 input
     public String encrypt(String message) {
         byte[] data = message.getBytes(UTF_8);
-        byte[] cipherbytes = encrypt(data)
-        return new String(cipherbytes, UTF_8)
+        byte[] cipherbytes = encrypt(data);
+        return new String(cipherbytes, UTF_8);
     }
 
     public byte[] decrypt(byte[] cipherbytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
@@ -134,14 +134,14 @@ public class RSA {
     // UTF-8 input
     public String decrypt(String message) {
         byte[] cipherbytes = message.getBytes(UTF_8);
-        byte[] data = decrypt(cipherbytes)
+        byte[] data = decrypt(cipherbytes);
         return new String(data, UTF_8);
     }
 
     // Base64 input
     public String decrypt64(String b64message) {
         byte[] cipherbytes = Base64.decode(b64message, Base64.DEFAULT);
-        byte[] data = decrypt(cipherbytes)
+        byte[] data = decrypt(cipherbytes);
         return Base64.encodeToString(data, Base64.DEFAULT);
     }
 

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -123,7 +123,7 @@ public class RSA {
         return new String(cipherBytes, UTF_8);
     }
 
-    public byte[] decrypt(byte[] cipherBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
+    private byte[] decrypt(byte[] cipherBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         String message = null;
         final Cipher cipher = Cipher.getInstance("RSA/NONE/PKCS1Padding");
         cipher.init(Cipher.DECRYPT_MODE, this.privateKey);
@@ -145,7 +145,7 @@ public class RSA {
         return Base64.encodeToString(data, Base64.DEFAULT);
     }
 
-    public String sign(byte[] messageBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+    private String sign(byte[] messageBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
         Signature privateSignature = Signature.getInstance("SHA512withRSA");
         privateSignature.initSign(this.privateKey);
         privateSignature.update(messageBytes);
@@ -165,7 +165,7 @@ public class RSA {
         return sign(messageBytes);
     }
 
-    public boolean verify(byte[] signatureBytes, byte[] messageBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+    private boolean verify(byte[] signatureBytes, byte[] messageBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
         Signature publicSignature = Signature.getInstance("SHA512withRSA");
         publicSignature.initVerify(this.publicKey);
         publicSignature.update(messageBytes);

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -110,14 +110,14 @@ public class RSA {
     }
 
     // Base64 input
-    public String encrypt64(String b64Message){
+    public String encrypt64(String b64Message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         byte[] data = Base64.decode(b64Message, Base64.DEFAULT);
         byte[] cipherbytes = encrypt(data);
         return Base64.encodeToString(cipherbytes, Base64.DEFAULT);
     }
 
     // UTF-8 input
-    public String encrypt(String message) {
+    public String encrypt(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         byte[] data = message.getBytes(UTF_8);
         byte[] cipherbytes = encrypt(data);
         return new String(cipherbytes, UTF_8);
@@ -132,14 +132,14 @@ public class RSA {
     }
 
     // UTF-8 input
-    public String decrypt(String message) {
+    public String decrypt(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         byte[] cipherbytes = message.getBytes(UTF_8);
         byte[] data = decrypt(cipherbytes);
         return new String(data, UTF_8);
     }
 
     // Base64 input
-    public String decrypt64(String b64message) {
+    public String decrypt64(String b64message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         byte[] cipherbytes = Base64.decode(b64message, Base64.DEFAULT);
         byte[] data = decrypt(cipherbytes);
         return Base64.encodeToString(data, Base64.DEFAULT);

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -7,7 +7,6 @@ import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.util.Base64;
 import android.util.Log;
-
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -103,7 +102,7 @@ public class RSA {
     // This function will be called by encrypt and encrypt64
     private byte[] encrypt(byte[] data) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         String encodedMessage = null;
-        final Cipher cipher = Cipher.getInstance("RSA/NONE/PKCS1Padding");
+        final Cipher cipher = Cipher.getInstance("RSA/NONE/OAEPWithSHA1AndMGF1Padding");
         cipher.init(Cipher.ENCRYPT_MODE, this.publicKey);
         byte[] cipherBytes = cipher.doFinal(data);
         return cipherBytes;
@@ -125,7 +124,7 @@ public class RSA {
 
     private byte[] decrypt(byte[] cipherBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         String message = null;
-        final Cipher cipher = Cipher.getInstance("RSA/NONE/PKCS1Padding");
+        final Cipher cipher = Cipher.getInstance("RSA/NONE/OAEPWithSHA1AndMGF1Padding");
         cipher.init(Cipher.DECRYPT_MODE, this.privateKey);
         byte[] data = cipher.doFinal(cipherBytes);
         return data;

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -120,7 +120,7 @@ public class RSA {
     public String encrypt(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         byte[] data = message.getBytes(UTF_8);
         byte[] cipherBytes = encrypt(data);
-        return new String(cipherBytes, UTF_8);
+        return Base64.encodeToString(cipherBytes, Base64.DEFAULT);
     }
 
     private byte[] decrypt(byte[] cipherBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
@@ -142,7 +142,7 @@ public class RSA {
     public String decrypt64(String b64message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         byte[] cipherBytes = Base64.decode(b64message, Base64.DEFAULT);
         byte[] data = decrypt(cipherBytes);
-        return Base64.encodeToString(data, Base64.DEFAULT);
+        return new String(data, UTF_8);
     }
 
     private String sign(byte[] messageBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -142,7 +142,7 @@ public class RSA {
     public String decrypt64(String b64message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException {
         byte[] cipherBytes = Base64.decode(b64message, Base64.DEFAULT);
         byte[] data = decrypt(cipherBytes);
-        return new String(data, UTF_8);
+        return Base64.encodeToString(data, Base64.DEFAULT);
     }
 
     private String sign(byte[] messageBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -63,11 +63,27 @@ RCT_EXPORT_METHOD(sign:(NSString *)message withKey:(NSString *)key resolve:(RCTP
     resolve(signature);
 }
 
+RCT_EXPORT_METHOD(sign64:(NSString *)message withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    RSANative *rsa = [[RSANative alloc] init];
+    rsa.privateKey = key;
+    NSString *signature = [rsa sign64:message];
+    resolve(signature);
+}
+
 RCT_EXPORT_METHOD(verify:(NSString *)signature withMessage:(NSString *)message andKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     RSANative *rsa = [[RSANative alloc] init];
     rsa.publicKey = key;
     BOOL valid = [rsa verify:signature withMessage:message];
+    resolve(@(valid));
+}
+
+RCT_EXPORT_METHOD(verify64:(NSString *)signature withMessage:(NSString *)message andKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    RSANative *rsa = [[RSANative alloc] init];
+    rsa.publicKey = key;
+    BOOL valid = [rsa verify64:signature withMessage:message];
     resolve(@(valid));
 }
 

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -38,6 +38,23 @@ RCT_EXPORT_METHOD(decrypt:(NSString *)encodedMessage withKey:(NSString *)key res
     resolve(message);
 }
 
+RCT_EXPORT_METHOD(encrypt64:(NSString *)message withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    RSANative *rsa = [[RSANative alloc] init];
+    rsa.publicKey = key;
+    NSString *encodedMessage = [rsa encrypt64:message];
+    resolve(encodedMessage);
+}
+
+RCT_EXPORT_METHOD(decrypt64:(NSString *)encodedMessage withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    RSANative *rsa = [[RSANative alloc] init];
+    rsa.privateKey = key;
+    NSString *message = [rsa decrypt64:encodedMessage];
+    resolve(message);
+}
+
+
 RCT_EXPORT_METHOD(sign:(NSString *)message withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     RSANative *rsa = [[RSANative alloc] init];

--- a/ios/RSANative.h
+++ b/ios/RSANative.h
@@ -27,8 +27,8 @@
 - (NSString *)encrypt64:(NSString *)message;
 - (NSString *)decrypt64:(NSString *)encodedMessage;
 
-- (NSString *)_encrypt:(NSData *)message;
-- (NSData *)_decrypt:(NSString *)encodedMessage;
+- (NSData *)_encrypt:(NSData *)message;
+- (NSData *)_decrypt:(NSData *)encodedMessage;
 
 - (NSString *)sign:(NSString *)message;
 - (BOOL)verify:(NSString *)signature withMessage:(NSString *)message;

--- a/ios/RSANative.h
+++ b/ios/RSANative.h
@@ -24,6 +24,9 @@
 - (NSString *)encrypt:(NSString *)message;
 - (NSString *)decrypt:(NSString *)encodedMessage;
 
+- (NSString *)encrypt64:(NSString *)message;
+- (NSString *)decrypt64:(NSString *)encodedMessage;
+
 - (NSString *)sign:(NSString *)message;
 - (BOOL)verify:(NSString *)signature withMessage:(NSString *)message;
 

--- a/ios/RSANative.h
+++ b/ios/RSANative.h
@@ -33,4 +33,10 @@
 - (NSString *)sign:(NSString *)message;
 - (BOOL)verify:(NSString *)signature withMessage:(NSString *)message;
 
+- (NSString *)sign64:(NSString *)b64message;
+- (BOOL)verify64:(NSString *)signature withMessage:(NSString *)b64message;
+
+- (NSString *)_sign:(NSData *)messageBytes;
+- (BOOL)_verify:(NSData *)signatureBytes withMessage:(NSData *)messageBytes;
+
 @end

--- a/ios/RSANative.h
+++ b/ios/RSANative.h
@@ -27,6 +27,9 @@
 - (NSString *)encrypt64:(NSString *)message;
 - (NSString *)decrypt64:(NSString *)encodedMessage;
 
+- (NSString *)_encrypt:(NSData *)message;
+- (NSData *)_decrypt:(NSString *)encodedMessage;
+
 - (NSString *)sign:(NSString *)message;
 - (BOOL)verify:(NSString *)signature withMessage:(NSString *)message;
 

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -145,48 +145,25 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 
 - (NSData *)_encrypt:(NSData *)data {
     __block NSData *cipherText = nil;
+
     void(^encryptor)(SecKeyRef) = ^(SecKeyRef publicKey) {
         BOOL canEncrypt = SecKeyIsAlgorithmSupported(publicKey,
                                                      kSecKeyOperationTypeEncrypt,
                                                      kSecKeyAlgorithmRSAEncryptionPKCS1);
+        NSData *plainText = [message dataUsingEncoding:NSUTF8StringEncoding];
+        canEncrypt &= ([plainText length] < (SecKeyGetBlockSize(publicKey)-130));
 
-        const uint8_t *srcbuf = (const uint8_t *)[data bytes];
-        size_t srclen = (size_t)data.length;
-        
-        size_t block_size = SecKeyGetBlockSize(publicKey) * sizeof(uint8_t);
-        void *outbuf = malloc(block_size);
-        size_t src_block_size = block_size - 11;
-        NSMutableData *ret = [[NSMutableData alloc] init];
-        for(int idx=0; idx<srclen; idx+=src_block_size){
-            //NSLog(@"%d/%d block_size: %d", idx, (int)srclen, (int)block_size);
-            size_t data_len = srclen - idx;
-            if(data_len > src_block_size){
-                data_len = src_block_size;
-            }
-            
-            size_t outlen = block_size;
-            OSStatus status = noErr;
-            
-
-            status = SecKeyEncrypt(publicKey,
-                                kSecPaddingPKCS1,
-                                srcbuf + idx,
-                                data_len,
-                                outbuf,
-                                &outlen
-                                );
-            
-            if (status != 0) {
-                NSLog(@"SecKeyEncrypt fail. Error Code: %d", status);
-                ret = nil;
-                break;
-            }else{
-                [ret appendBytes:outbuf length:outlen];
+        if (canEncrypt) {
+            CFErrorRef error = NULL;
+            cipherText = (NSData *)CFBridgingRelease(SecKeyCreateEncryptedData(publicKey,
+                                                                               kSecKeyAlgorithmRSAEncryptionPKCS1,
+                                                                               (__bridge CFDataRef)plainText,
+                                                                               &error));
+            if (!cipherText) {
+                NSError *err = CFBridgingRelease(error);
+                NSLog(@"%@", err);
             }
         }
-        
-        free(outbuf);
-        cipherText = ret;
     };
 
     if (self.keyTag) {
@@ -214,55 +191,24 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
     __block NSData *clearText = nil;
 
     void(^decryptor)(SecKeyRef) = ^(SecKeyRef privateKey) {
-        const uint8_t *srcbuf = (const uint8_t *)[data bytes];
-        size_t srclen = (size_t)data.length;
-        
-        size_t block_size = SecKeyGetBlockSize(privateKey) * sizeof(uint8_t);
-        UInt8 *outbuf = malloc(block_size);
-        size_t src_block_size = block_size;
-        
-        NSMutableData *ret = [[NSMutableData alloc] init];
-        for(int idx=0; idx<srclen; idx+=src_block_size){
-            //NSLog(@"%d/%d block_size: %d", idx, (int)srclen, (int)block_size);
-            size_t data_len = srclen - idx;
-            if(data_len > src_block_size){
-                data_len = src_block_size;
-            }
-            
-            size_t outlen = block_size;
-            OSStatus status = noErr;
-            status = SecKeyDecrypt(privateKey,
-                                kSecPaddingNone,
-                                srcbuf + idx,
-                                data_len,
-                                outbuf,
-                                &outlen
-                                );
-            if (status != 0) {
-                NSLog(@"SecKeyEncrypt fail. Error Code: %d", status);
-                ret = nil;
-                break;
-            }else{
-                //the actual decrypted data is in the middle, locate it!
-                int idxFirstZero = -1;
-                int idxNextZero = (int)outlen;
-                for ( int i = 0; i < outlen; i++ ) {
-                    if ( outbuf[i] == 0 ) {
-                        if ( idxFirstZero < 0 ) {
-                            idxFirstZero = i;
-                        } else {
-                            idxNextZero = i;
-                            break;
-                        }
-                    }
-                }
-                
-                [ret appendBytes:&outbuf[idxFirstZero+1] length:idxNextZero-idxFirstZero-1];
+        NSData *cipherText = [[NSData alloc] initWithBase64EncodedString:encodedMessage options:NSDataBase64DecodingIgnoreUnknownCharacters];
+
+        BOOL canDecrypt = SecKeyIsAlgorithmSupported(privateKey,
+                                                     kSecKeyOperationTypeDecrypt,
+                                                     kSecKeyAlgorithmRSAEncryptionPKCS1);
+        canDecrypt &= ([cipherText length] == SecKeyGetBlockSize(privateKey));
+
+        if (canDecrypt) {
+            CFErrorRef error = NULL;
+            clearText = (NSData *)CFBridgingRelease(SecKeyCreateDecryptedData(privateKey,
+                                                                              kSecKeyAlgorithmRSAEncryptionPKCS1,
+                                                                              (__bridge CFDataRef)cipherText,
+                                                                              &error));
+            if (!clearText) {
+                NSError *err = CFBridgingRelease(error);
+                NSLog(@"%@", err);
             }
         }
-        
-        free(outbuf);
-        clearText = ret;
     };
 
     if (self.keyTag) {

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -133,12 +133,12 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 
 - (NSString *)encrypt64:(NSString*)message {
     NSData *decodedData = [[NSData alloc] initWithBase64EncodedString:message options:0];    
-    return [self._encrypt data];
+    return [self _encrypt: decodedData];
 }
 
 - (NSString *)encrypt:(NSString *)message {
     NSData *data = [message dataUsingEncoding:NSUTF8StringEncoding];
-    return [self._encrypt data];
+    return [self _encrypt: data];
 }
 
 - (NSData *)_encrypt:(NSData *)data {
@@ -197,13 +197,13 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 }
 
 - (NSString *)decrypt64:(NSString*)message {
-    NSData *data = [self._decrypt message];
+    NSData *data = [self _decrypt: message];
     NSString *base64String = [data base64EncodedStringWithOptions:0];
     return base64String;
 }
 
 - (NSString *)decrypt:(NSString *)message {
-    NSData *data = [self._decrypt message];
+    NSData *data = [self _decrypt: message];
     return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }
 

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -197,14 +197,14 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 }
 
 - (NSString *)decrypt64:(NSString*)message {
-    NSData *data = [self._decrypt message]
+    NSData *data = [self._decrypt message];
     NSString *base64String = [data base64EncodedStringWithOptions:0];
     return base64String;
 }
 
 - (NSString *)decrypt:(NSString *)message {
-    NSData *data = [self._decrypt message]
-    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]
+    NSData *data = [self._decrypt message];
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }
 
 - (NSData *)_decrypt:(NSString *)encodedMessage {

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -134,7 +134,7 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 - (NSString *)encrypt64:(NSString*)message {
     NSData *data = [[NSData alloc] initWithBase64EncodedString:message options:NSDataBase64DecodingIgnoreUnknownCharacters];
     NSData *encrypted = [self _encrypt: data];
-    return [encrypted base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+    return [encrypted base64EncodedStringWithOptions:];
 }
 
 - (NSString *)encrypt:(NSString *)message {
@@ -201,7 +201,7 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 - (NSString *)decrypt64:(NSString*)message {
     NSData *data = [[NSData alloc] initWithBase64EncodedString:message options:NSDataBase64DecodingIgnoreUnknownCharacters];
     NSData *decrypted = [self _decrypt: data];
-    return [decrypted base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+    return [decrypted base64EncodedStringWithOptions:];
 }
 
 - (NSString *)decrypt:(NSString *)message {

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -132,7 +132,7 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 }
 
 - (NSString *)encrypt64:(NSString*)message {
-    NSData *data = [[NSData alloc] initWithBase64EncodedString:cipherText options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:message options:NSDataBase64DecodingIgnoreUnknownCharacters];
     NSData *encrypted = [self _encrypt: data];
     return [encrypted base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
 }
@@ -140,7 +140,7 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 - (NSString *)encrypt:(NSString *)message {
     NSData *data = [message dataUsingEncoding:NSUTF8StringEncoding];
     NSData *encrypted = [self _encrypt: data];
-    return [[NSString alloc] initWithData:encrypted encoding:NSUTF8StringEncoding];
+    return [encrypted base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
 }
 
 - (NSData *)_encrypt:(NSData *)data {
@@ -199,13 +199,13 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 }
 
 - (NSString *)decrypt64:(NSString*)message {
-    NSData *data = [[NSData alloc] initWithBase64EncodedString:cipherText options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:message options:NSDataBase64DecodingIgnoreUnknownCharacters];
     NSData *decrypted = [self _decrypt: data];
     return [decrypted base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
 }
 
 - (NSString *)decrypt:(NSString *)message {
-    NSData *data = [message dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:message options:NSDataBase64DecodingIgnoreUnknownCharacters];
     NSData *decrypted = [self _decrypt: data];
     return [[NSString alloc] initWithData:decrypted encoding:NSUTF8StringEncoding];
 }
@@ -322,7 +322,7 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
     return encodedSignature;
 }
 
-- (BOOL)verify64:(NSData *)encodedSignature withMessage:(NSData *)b64message {
+- (BOOL)verify64:(NSString *)encodedSignature withMessage:(NSString *)b64message {
     NSData *messageBytes = [[NSData alloc] initWithBase64EncodedString:b64message options:NSDataBase64DecodingIgnoreUnknownCharacters];
     NSData *signatureBytes = [[NSData alloc] initWithBase64EncodedString:encodedSignature options:NSDataBase64DecodingIgnoreUnknownCharacters];
     return [self _verify: signatureBytes withMessage: messageBytes];

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -132,13 +132,15 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 }
 
 - (NSString *)encrypt64:(NSString*)message {
-    NSData *decodedData = [[NSData alloc] initWithBase64EncodedString:message options:0];    
-    return [self _encrypt: decodedData];
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:cipherText options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *encrypted = [self _encrypt: data];
+    return [encrypted base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
 }
 
 - (NSString *)encrypt:(NSString *)message {
     NSData *data = [message dataUsingEncoding:NSUTF8StringEncoding];
-    return [self _encrypt: data];
+    NSData *encrypted = [self _encrypt: data];
+    return [[NSString alloc] initWithData:encrypted encoding:NSUTF8StringEncoding];
 }
 
 - (NSData *)_encrypt:(NSData *)data {
@@ -193,23 +195,23 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
         encryptor(self.publicKeyRef);
     }
 
-    return [cipherText base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+    return cipherText;
 }
 
 - (NSString *)decrypt64:(NSString*)message {
-    NSData *data = [self _decrypt: message];
-    NSString *base64String = [data base64EncodedStringWithOptions:0];
-    return base64String;
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:cipherText options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    NSData *decrypted = [self _decrypt: data];
+    return [decrypted base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
 }
 
 - (NSString *)decrypt:(NSString *)message {
-    NSData *data = [self _decrypt: message];
-    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    NSData *data = [message dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *decrypted = [self _decrypt: data];
+    return [[NSString alloc] initWithData:decrypted encoding:NSUTF8StringEncoding];
 }
 
-- (NSData *)_decrypt:(NSString *)encodedMessage {
+- (NSData *)_decrypt:(NSData *)data {
     __block NSData *clearText = nil;
-    NSData *data = [[NSData alloc] initWithBase64EncodedString:encodedMessage options:NSDataBase64DecodingIgnoreUnknownCharacters];
 
     void(^decryptor)(SecKeyRef) = ^(SecKeyRef privateKey) {
         const uint8_t *srcbuf = (const uint8_t *)[data bytes];

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -149,11 +149,11 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
     void(^encryptor)(SecKeyRef) = ^(SecKeyRef publicKey) {
         BOOL canEncrypt = SecKeyIsAlgorithmSupported(publicKey,
                                                      kSecKeyOperationTypeEncrypt,
-                                                     kSecKeyAlgorithmRSAEncryptionPKCS1);
+                                                     kSecKeyAlgorithmRSAEncryptionOAEPSHA1);
         if (canEncrypt) {
             CFErrorRef error = NULL;
             cipherText = (NSData *)CFBridgingRelease(SecKeyCreateEncryptedData(publicKey,
-                                                                               kSecKeyAlgorithmRSAEncryptionPKCS1,
+                                                                               kSecKeyAlgorithmRSAEncryptionOAEPSHA1,
                                                                                (__bridge CFDataRef)data,
                                                                                &error));
             if (!cipherText) {
@@ -191,11 +191,11 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 
         BOOL canDecrypt = SecKeyIsAlgorithmSupported(privateKey,
                                                      kSecKeyOperationTypeDecrypt,
-                                                     kSecKeyAlgorithmRSAEncryptionPKCS1);
+                                                     kSecKeyAlgorithmRSAEncryptionOAEPSHA1);
         if (canDecrypt) {
             CFErrorRef error = NULL;
             clearText = (NSData *)CFBridgingRelease(SecKeyCreateDecryptedData(privateKey,
-                                                                              kSecKeyAlgorithmRSAEncryptionPKCS1,
+                                                                              kSecKeyAlgorithmRSAEncryptionOAEPSHA1,
                                                                               (__bridge CFDataRef)data,
                                                                               &error));
             if (!clearText) {


### PR DESCRIPTION
Allows user to specify arbitrary bytes to encrypt/decrypt, important for encrypted AES keys.   Works on IOS.

- An AES key should be used for longer data, and the AES key+IV should be public key encrypted and prepended  to the data if it is used.   I like this format:

      `typebits(4)+keylength(12)+iv(16)+key(v)+ciphertext....`

- But this format isn't used by everyone, and honestly, every library is different enough that you will always need the bytes/binary versions.
 
- If you want to cleanly encrypt/decrypt arbitrary length text, you need to use RSA+AES... and it should probably be a separate library, or at least a separate set of functions.

- Most people who are programming for mobile will need to be compatible with other devices... so byte-for-byte surity and no special null-byte encodings are probably best.

- Probably better to throw an exception than to silently return null if the data is too large

- Also moved to OAEP/SHA1, because of some incompatiblity between ios/android/node with V1.5.   
