### PR TITLE
Guard access to retrieving the private key from the Android keystore

### DIFF
--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -199,8 +199,11 @@ public class RSA {
         KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
         keyStore.load(null);
         KeyStore.PrivateKeyEntry privateKeyEntry = (KeyStore.PrivateKeyEntry) keyStore.getEntry(this.keyTag, null);
-        this.privateKey = privateKeyEntry.getPrivateKey();
-        this.publicKey = privateKeyEntry.getCertificate().getPublicKey();
+
+        if (privateKeyEntry != null) {
+            this.privateKey = privateKeyEntry.getPrivateKey();
+            this.publicKey = privateKeyEntry.getCertificate().getPublicKey();
+        }
     }
 
     public void deletePrivateKey() throws KeyStoreException, UnrecoverableEntryException, NoSuchAlgorithmException, IOException, CertificateException {


### PR DESCRIPTION
Hi @amitaymolko 

Hope all is going well mate.

Just a little PR for your review - this protects against getting a null pointer on the privateKeyEntry reference from the Android KeyStore when no key has been generated, eg. after construction of the RSA object.

Cheers mate. Happy to adjust if you'd prefer an alternate solution, let me know?

M!