### PR TITLE
Add support for Android API < 23

### DIFF
--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -32,7 +32,7 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
 
     try {
         RSA rsa = new RSA();
-        rsa.generate(keyTag);
+        rsa.generate(keyTag, this.reactContext);
         keys.putString("public",  rsa.getPublicKey());
         promise.resolve(keys);
     } catch(NoSuchAlgorithmException e) {


### PR DESCRIPTION
KeyGenParameterSpec was added on API 23, and so keychain RSA key generation crashes on these versions of Android.

This PR fixes this by using previous APIs for old versions of Android.

Does this seem OK to you?