### PR TITLE
exposing getPublicKey from RSA to react native on both ios and android

### DIFF
--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -158,6 +158,22 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void getPublicKey(String keyTag, Promise promise)  {
+      WritableNativeMap keys = new WritableNativeMap();
+
+      try {
+          RSA rsa = new RSA(keyTag);
+          String publicKey = rsa.getPublicKey();
+          if (publicKey != null) {
+            keys.putString("public",  publicKey);
+          }
+          promise.resolve(keys);
+      } catch(Exception e) {
+        promise.reject("Error", e.getMessage());
+      }
+    }
+
 
 
 }

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -142,4 +142,11 @@ RCT_EXPORT_METHOD(verify:(NSString *)signature withMessage:(NSString *)message a
     resolve(@(valid));
 }
 
+RCT_EXPORT_METHOD(getPublicKey:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
+    NSString *key = [rsa encodedPublicKey];
+    resolve(key);
+}
+
 @end


### PR DESCRIPTION
I needed to be able to get the public key for a keyTag from the keystore after it was generated.  I exposed this from the RSA code to react native on both iOS and android.