### PR TITLE
iOS: Use dispatch_async for expensive tasks

### DIFF
--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -18,78 +18,96 @@ RCT_EXPORT_METHOD(generate:(RCTPromiseResolveBlock)resolve
 
 RCT_EXPORT_METHOD(generateKeys:(int)keySize resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] init];
-    [rsa generate:keySize];
-    NSDictionary *keys = @{
-                           @"private" : [rsa encodedPrivateKey],
-                           @"public" : [rsa encodedPublicKey]
-                           };
-    resolve(keys);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] init];
+        [rsa generate:keySize];
+        NSDictionary *keys = @{
+                            @"private" : [rsa encodedPrivateKey],
+                            @"public" : [rsa encodedPublicKey]
+                            };
+        resolve(keys);
+    });
 }
 
 RCT_EXPORT_METHOD(encrypt:(NSString *)message withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] init];
-    rsa.publicKey = key;
-    NSString *encodedMessage = [rsa encrypt:message];
-    resolve(encodedMessage);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] init];
+        rsa.publicKey = key;
+        NSString *encodedMessage = [rsa encrypt:message];
+        resolve(encodedMessage);
+    });
 }
 
 RCT_EXPORT_METHOD(decrypt:(NSString *)encodedMessage withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] init];
-    rsa.privateKey = key;
-    NSString *message = [rsa decrypt:encodedMessage];
-    resolve(message);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] init];
+        rsa.privateKey = key;
+        NSString *message = [rsa decrypt:encodedMessage];
+        resolve(message);
+    });
 }
 
 RCT_EXPORT_METHOD(encrypt64:(NSString *)message withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] init];
-    rsa.publicKey = key;
-    NSString *encodedMessage = [rsa encrypt64:message];
-    resolve(encodedMessage);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] init];
+        rsa.publicKey = key;
+        NSString *encodedMessage = [rsa encrypt64:message];
+        resolve(encodedMessage);
+    });
 }
 
 RCT_EXPORT_METHOD(decrypt64:(NSString *)encodedMessage withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] init];
-    rsa.privateKey = key;
-    NSString *message = [rsa decrypt64:encodedMessage];
-    resolve(message);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] init];
+        rsa.privateKey = key;
+        NSString *message = [rsa decrypt64:encodedMessage];
+        resolve(message);
+    });
 }
 
 
 RCT_EXPORT_METHOD(sign:(NSString *)message withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] init];
-    rsa.privateKey = key;
-    NSString *signature = [rsa sign:message];
-    resolve(signature);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] init];
+        rsa.privateKey = key;
+        NSString *signature = [rsa sign:message];
+        resolve(signature);
+    });
 }
 
 RCT_EXPORT_METHOD(sign64:(NSString *)message withKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] init];
-    rsa.privateKey = key;
-    NSString *signature = [rsa sign64:message];
-    resolve(signature);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] init];
+        rsa.privateKey = key;
+        NSString *signature = [rsa sign64:message];
+        resolve(signature);
+    });
 }
 
 RCT_EXPORT_METHOD(verify:(NSString *)signature withMessage:(NSString *)message andKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] init];
-    rsa.publicKey = key;
-    BOOL valid = [rsa verify:signature withMessage:message];
-    resolve(@(valid));
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] init];
+        rsa.publicKey = key;
+        BOOL valid = [rsa verify:signature withMessage:message];
+        resolve(@(valid));
+    });
 }
 
 RCT_EXPORT_METHOD(verify64:(NSString *)signature withMessage:(NSString *)message andKey:(NSString *)key resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] init];
-    rsa.publicKey = key;
-    BOOL valid = [rsa verify64:signature withMessage:message];
-    resolve(@(valid));
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] init];
+        rsa.publicKey = key;
+        BOOL valid = [rsa verify64:signature withMessage:message];
+        resolve(@(valid));
+    });
 }
 
 @end
@@ -111,10 +129,12 @@ RCT_EXPORT_METHOD(generate:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)re
 
 RCT_EXPORT_METHOD(generateKeys:(NSString *)keyTag keySize:(int)keySize resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-    [rsa generate:keySize];
-    NSDictionary *keys = @{@"public" : [rsa encodedPublicKey]};
-    resolve(keys);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
+        [rsa generate:keySize];
+        NSDictionary *keys = @{@"public" : [rsa encodedPublicKey]};
+        resolve(keys);
+    });
 }
 
 RCT_EXPORT_METHOD(deletePrivateKey:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve
@@ -126,30 +146,38 @@ RCT_EXPORT_METHOD(deletePrivateKey:(NSString *)keyTag resolve:(RCTPromiseResolve
 
 RCT_EXPORT_METHOD(encrypt:(NSString *)message withKeyTag:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-    NSString *encodedMessage = [rsa encrypt:message];
-    resolve(encodedMessage);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
+        NSString *encodedMessage = [rsa encrypt:message];
+        resolve(encodedMessage);
+    });
 }
 
 RCT_EXPORT_METHOD(decrypt:(NSString *)encodedMessage withKeyTag:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-    NSString *message = [rsa decrypt:encodedMessage];
-    resolve(message);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
+        NSString *message = [rsa decrypt:encodedMessage];
+        resolve(message);
+    });
 }
 
 RCT_EXPORT_METHOD(sign:(NSString *)message withKeyTag:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-    NSString *signature = [rsa sign:message];
-    resolve(signature);
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
+        NSString *signature = [rsa sign:message];
+        resolve(signature);
+    });
 }
 
 RCT_EXPORT_METHOD(verify:(NSString *)signature withMessage:(NSString *)message andKeyTag:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-    BOOL valid = [rsa verify:signature withMessage:message];
-    resolve(@(valid));
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
+        BOOL valid = [rsa verify:signature withMessage:message];
+        resolve(@(valid));
+    });
 }
 
 RCT_EXPORT_METHOD(getPublicKey:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
Key generation (and other tasks) are expensive. This wraps following
operations into a `dispatch_async` statement so the UI thread of iOS is
not blocked:

* Plain keys:
  * `generateKeys`
  * `encrypt`/`encrypt64`
  * `decrypt`/`decrypt64`
  * `sign`/`sign64`
  * `verify`/`verify64`
* Keychain-based:
  * `generateKeys`
  * `encrypt`
  * `decrypt`
  * `sign`
  * `verify`

This change cares only about iOS so far. Will gladly provide an additional PR for Android once I tackle that platform and face the same problems :)