### PR TITLE
Feature/improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Decrypt a given encrypted message using the private key.
 
 #### sign
 `static sign(message: string, privateKey : string) : Promise<string>`
+
 Sign a given message with the private key, so that any user with the message, the returned signature, and the matching public key can verify it was signed under this key.
 
 #### verify
@@ -83,6 +84,49 @@ the private key is stored in the underlying operating system's keychain
 using a tag which the app can use to access it.
 Methods then take this tag instead of the private key.
 
+#### generateKeys
+`static generateKeys(keySize : number, keyTag : string) : Promise<PublicKey>`
+
+Generate a public/private key pair of the given key size,
+and store the private key in the operating system keychain.
+
+#### generate
+`static generate(keyTag : string) : Promise<KeyPair>`
+
+Equivalent to `generateKeys(2048, keyTag)`
+
+#### encrypt
+`static encrypt(message : string, keyTag : string) : Promise<string>`
+
+Retrieve the public key associated with the key tag,
+and encrypt a given message with that key,
+so it is decryptable with the matching private key.
+
+#### decrypt
+`static decrypt(encodedMessage : string, keyTag : string) : Promise<string>`
+
+Decrypt a given encrypted message using the private key
+associated with the given key tag.
+
+#### sign
+`static sign(message: string, keyTag : string) : Promise<string>`
+
+Sign a given message with the private key associated with the given key tag,
+so that any user with
+the message, the returned signature, and the matching public key
+can verify it was signed under this key.
+
+#### verify
+`static verify(signature : string, message : string, keyTag : string) : Promise<boolean>`
+
+Verify whether or not a provided signature was produced by signing the given message with private key associated with the given key tag.
+
+#### deletePrivateKey
+`static deletePrivateKey(keyTag : string) : Promise<boolean>`
+
+Delete the private key from the operating system's keychain.
+Returns true if the key was removed successfully.
+
 ### KeyPair Type
 
 Note: The `KeyPair` type does not strictly exist.
@@ -92,6 +136,16 @@ of other methods.
 Property | Description
 --|--
 `private : string` | The RSA private key.
+`public : string` | The RSA public key.
+
+### PublicKey Type
+
+Note: The `PublicKey` type does not strictly exist.
+Documentation provided here for convenience of understanding the return types
+of other methods.
+
+Property | Description
+--|--
 `public : string` | The RSA public key.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -35,6 +35,72 @@ or:
 
 In your React Native Xcode project, right click on your project and go 'Add Files to ...', then navigate to <your-project-root>/node_modules/react-native-rsa-native/ios and select the RNRSA.xcodeproj file. Then in the build settings for your target under 'Link Binary With Libraries', add libRNRSA.a.
 
+## Example Usage
+
+These basic examples show a typical use case using both promise chains
+and async/await.
+See [the full API documentation below](#documentation)
+for more detail on the methods available.
+
+### Encrypt a message
+
+Encrypt a message and subsequently decrypt it,
+using the RSA class in a promise chain structure.
+
+```js
+import { RSA } from 'react-native-rsa-native';
+
+let message = "my secret message";
+
+RSA.generateKeys(4096) // set key size
+.then(keys => {
+    console.log('4096 private:', keys.private); // the private key
+    console.log('4096 public:', keys.public); // the public key
+    RSA.encrypt(message, keys.public)
+    .then(encodedMessage => {
+        console.log(`the encoded message is ${encodedMessage}`);
+        RSA.decrypt(encodedMessage, keys.private)
+        .then(decryptedMessage => {
+            console.log(`The original message was ${decryptedMessage}`);
+        });
+    });
+});
+```
+
+### Sign a message
+
+Sign a message and subsequently verify it,
+using the RSAKeychain class in an async/await structure.
+
+```typescript
+import { RSAKeychain } from 'react-native-rsa-native';
+
+async main() {
+    let keyTag = 'com.domain.mykey';
+    let message = "message to be verified";
+
+    let publicKey = await generateKeyPair(keyTag);
+    // Share the generated public key with third parties as desired.
+
+    let messageSignature = await RSAKeychain.sign(message, keyTag);
+
+    if (await RSAKeychain.verify(messageSignature, message, keyTag)) {
+        // The signature matches: trust this message.
+    } else {
+        // The signature does not match.
+    }
+
+    await RSAKeychain.deletePrivateKey(keyTag);
+}
+
+async generateKeyPair(keyTag : string) {
+    let keys = await RSAKeychain.generate(keyTag);
+    return keys.public;
+}
+```
+
+Check out example App.js for a full example
+
 ## Documentation
 ### RSA Class
 
@@ -147,82 +213,6 @@ of other methods.
 Property | Description
 --|--
 `public : string` | The RSA public key.
-
-## Usage
-
-```
-
-import {RSA, RSAKeychain} from 'react-native-rsa-native';
-
-RSA.generateKeys(4096) // set key size
-  .then(keys => {
-    console.log('4096 private:', keys.private) // the private key
-    console.log('4096 public:', keys.public) // the public key
-  })
-
-RSA.generate()
-  .then(keys => {
-    console.log(keys.private) // the private key
-    console.log(keys.public) // the public key
-    RSA.encrypt('1234', keys.public)
-      .then(encodedMessage => {
-        RSA.decrypt(encodedMessage, keys.private)
-          .then(message => {
-            console.log(message);
-          })
-        })
-
-    RSA.sign(secret, keys.private)
-      .then(signature => {
-        console.log(signature);
-
-        RSA.verify(signature, secret, keys.public)
-          .then(valid => {
-            console.log(valid);
-          })
-        })
-  })
-
-// Example utilizing the keychain for private key secure storage
-
-let keyTag = 'com.domain.mykey';
-let secret = "secret message";
-
-RSAKeychain.generate(keyTag)
-  .then(keys => {
-    console.log(keys.public);
-    console.log(secret);
-
-    return RSAKeychain.encrypt(secret, keyTag)
-      .then(encodedMessage => {
-        console.log(encodedMessage);
-
-        RSAKeychain.decrypt(encodedMessage, keyTag)
-          .then(message => {
-            console.log(message);
-          })
-        })
-  })
-  .then(() => {
-  return RSAKeychain.sign(secret, keyTag)
-    .then(signature => {
-      console.log('signature', signature);
-
-      RSAKeychain.verify(signature, secret, keyTag)
-        .then(valid => {
-          console.log('verified', valid);
-        })
-      })
-  })
-  .then(() => {
-    RSAKeychain.deletePrivateKey(keyTag)
-    .then( success => {
-      console.log('delete success', success)
-    })
-  });
-```
-Check out example App.js for a full example
-
 
 ## Credit
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ In your React Native Xcode project, right click on your project and go 'Add File
 
 ## Documentation
 ### RSA Class
+
+A class that performs RSA cryptographic primitives
+in a simple and straightforward manner.
+If you would prefer to use the underlying operating system's built-in
+security keychain, use [the RSAKeychain Class](#rsakeychain-class) instead.
+
 #### generateKeys
 `static generateKeys(keySize : number) : Promise<KeyPair>`
 
@@ -67,6 +73,15 @@ Sign a given message with the private key, so that any user with the message, th
 Verify whether or not a provided signature was produced by signing the given message with the private key paired to the provided public key.
 
 ### RSAKeychain Class
+
+Like [the RSA Class](#rsa-class),
+but when its methods are called, instead of directly accessing the private key,
+the private key is stored in the underlying operating system's keychain
+(see documentation
+[for iOS](https://developer.apple.com/documentation/security/keychain_services) and
+[for Android](https://developer.android.com/reference/android/security/KeyChain))
+using a tag which the app can use to access it.
+Methods then take this tag instead of the private key.
 
 ### KeyPair Type
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ android 4.1+ (API 16)
 
 ## Status
 
-Features: 
-Generation, 
-Encryption, 
-Decryption, 
-Sign, 
-Verify, 
+Features:
+Generation,
+Encryption,
+Decryption,
+Sign,
+Verify,
 Keychain support
 
 ## Getting started
@@ -35,6 +35,32 @@ or:
 
 In your React Native Xcode project, right click on your project and go 'Add Files to ...', then navigate to <your-project-root>/node_modules/react-native-rsa-native/ios and select the RNRSA.xcodeproj file. Then in the build settings for your target under 'Link Binary With Libraries', add libRNRSA.a.
 
+## Documentation
+
+### RSA Class
+
+Method signature | Description
+--|--|--
+`static generateKeys(keySize : number) : Promise<KeyPair>` | Generate a public/private key pair of the given key size.
+`static generate() : Promise<KeyPair>` | Equivalent to `generateKeys(2048)`
+`static encrypt(message : string, publicKey : string) : Promise<string>` | Encrypt a given message with the provided public key, so it is decryptable with the matching private key.
+`static decrypt(encodedMessage : string, privateKey : string) : Promise<string>` | Decrypt a given encrypted message using the private key.
+`static sign(message: string, privateKey : string) : Promise<string>` | Sign a given message with the private key, so that any user with the message, the returned signature, and the matching public key can verify it was signed under this key.
+`static verify(signature : string, message : string, publicKey : string) : Promise<boolean>` | Verify whether or not a provided signature was produced by signing the given message with the private key paired to the provided public key.
+
+### RSAKeychain Class
+
+### KeyPair Type
+
+Note: The `KeyPair` type does not strictly exist.
+Documentation provided here for convenience of understanding the return types
+of other methods.
+
+Property | Description
+--|--
+`private : string` | The RSA private key.
+`public : string` | The RSA public key.
+
 ## Usage
 
 ```
@@ -47,7 +73,7 @@ RSA.generateKeys(4096) // set key size
     console.log('4096 public:', keys.public) // the public key
   })
 
-RSA.generate() 
+RSA.generate()
   .then(keys => {
     console.log(keys.private) // the private key
     console.log(keys.public) // the public key

--- a/README.md
+++ b/README.md
@@ -36,17 +36,35 @@ or:
 In your React Native Xcode project, right click on your project and go 'Add Files to ...', then navigate to <your-project-root>/node_modules/react-native-rsa-native/ios and select the RNRSA.xcodeproj file. Then in the build settings for your target under 'Link Binary With Libraries', add libRNRSA.a.
 
 ## Documentation
-
 ### RSA Class
+#### generateKeys
+`static generateKeys(keySize : number) : Promise<KeyPair>`
 
-Method signature | Description
---|--|--
-`static generateKeys(keySize : number) : Promise<KeyPair>` | Generate a public/private key pair of the given key size.
-`static generate() : Promise<KeyPair>` | Equivalent to `generateKeys(2048)`
-`static encrypt(message : string, publicKey : string) : Promise<string>` | Encrypt a given message with the provided public key, so it is decryptable with the matching private key.
-`static decrypt(encodedMessage : string, privateKey : string) : Promise<string>` | Decrypt a given encrypted message using the private key.
-`static sign(message: string, privateKey : string) : Promise<string>` | Sign a given message with the private key, so that any user with the message, the returned signature, and the matching public key can verify it was signed under this key.
-`static verify(signature : string, message : string, publicKey : string) : Promise<boolean>` | Verify whether or not a provided signature was produced by signing the given message with the private key paired to the provided public key.
+Generate a public/private key pair of the given key size.
+
+#### generate
+`static generate() : Promise<KeyPair>`
+
+Equivalent to `generateKeys(2048)`
+
+#### encrypt
+`static encrypt(message : string, publicKey : string) : Promise<string>`
+
+Encrypt a given message with the provided public key, so it is decryptable with the matching private key.
+
+#### decrypt
+`static decrypt(encodedMessage : string, privateKey : string) : Promise<string>`
+
+Decrypt a given encrypted message using the private key.
+
+#### sign
+`static sign(message: string, privateKey : string) : Promise<string>`
+Sign a given message with the private key, so that any user with the message, the returned signature, and the matching public key can verify it was signed under this key.
+
+#### verify
+`static verify(signature : string, message : string, publicKey : string) : Promise<boolean>`
+
+Verify whether or not a provided signature was produced by signing the given message with the private key paired to the provided public key.
 
 ### RSAKeychain Class
 


### PR DESCRIPTION
Fixes #35 

Note, I'm not completely sure about some of the types in here. Would appreciate feedback on them where appropriate.

In particular:

* Does `RSAKeychain.generateKeys(number)` exist? I've assumed it does, but the existing examples don't make it clear.
* Does the response to `RSAKeychain.generate(keyTag)` contain only `public`, or does `private` also exist? Since the example only contained `public`, I have not included private, so I described a different type. If `private` does exist, the documentation could instead re-use the existing one.
* What types are the public and private keys? I have assumed strings.
* What types do the `encrypt` and `sign` methods return? I have assumed strings.