### PR TITLE
SHA256withRSA algorithm for signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,16 @@ so that any user with
 the message, the returned signature, and the matching public key
 can verify it was signed under this key.
 
+#### signWithAlgorithm
+`static sign(message: string, keyTag : string, signature?: 'SHA256withRSA' | 'SHA512withRSA') : Promise<string>`
+
+Sign a given message with the private key associated with the given key tag,
+so that any user with
+the message, the returned signature, and the matching public key
+can verify it was signed under this key. The user can use __SHA256withRSA__ or __SHA512withRSA__ algorithm for signing. 
+__SHA256withRSA__ algorithm is not backward compatible on android and the user needs to generate new keypair for this to work. (available from ^2.0.0). The default is __SHA512withRSA__ and if one wishes to use __SHA512withRSA__ for signing without new keypair, then use the above sign method.
+
+
 #### verify
 `static verify(signature : string, message : string, keyTag : string) : Promise<boolean>`
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,13 +1,22 @@
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
 
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.3.2'
+    }
+}
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {
@@ -20,9 +29,9 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.+'
-    compile 'com.madgag.spongycastle:core:1.56.0.0'
-    compile 'com.madgag.spongycastle:prov:1.56.0.0'
-    compile 'com.madgag.spongycastle:bcpkix-jdk15on:1.56.0.0'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.madgag.spongycastle:core:1.56.0.0'
+    implementation 'com.madgag.spongycastle:prov:1.56.0.0'
+    implementation 'com.madgag.spongycastle:bcpkix-jdk15on:1.56.0.0'
 }
   

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 05 09:44:20 IDT 2017
+#Fri May 24 13:48:59 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -17,8 +17,8 @@ import java.util.Map;
 
 public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
 
-  private static final String SHA256WithRSA = "SHA256withRSA";
-  private static final String SHA512WithRSA = "SHA512withRSA";
+  private static final String SHA256withRSA = "SHA256withRSA";
+  private static final String SHA512withRSA = "SHA512withRSA";
   private static final String Digest_SHA256 = "SHA-256";
   private static final String Digest_SHA512 = "SHA-512";
 
@@ -37,8 +37,8 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
   @Override
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
-    constants.put(SHA256WithRSA, SHA256WithRSA);
-    constants.put(SHA512WithRSA, SHA512WithRSA);
+    constants.put(SHA256withRSA, SHA256withRSA);
+    constants.put(SHA512withRSA, SHA512withRSA);
     constants.put(Digest_SHA256, Digest_SHA256);
     constants.put(Digest_SHA512, Digest_SHA512);
     return constants;
@@ -186,7 +186,7 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
       public void run() {
         try {
           RSA rsa = new RSA(keyTag);
-          String signature = rsa.sign(message, SHA512WithRSA);
+          String signature = rsa.sign(message, SHA512withRSA);
           promise.resolve(signature);
 
         } catch (Exception e) {

--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -186,7 +186,7 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
       public void run() {
         try {
           RSA rsa = new RSA(keyTag);
-          String signature = rsa.sign(message, SHA512WITHRSA);
+          String signature = rsa.sign(message, SHA512WithRSA);
           promise.resolve(signature);
 
         } catch (Exception e) {

--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -17,8 +17,10 @@ import java.util.Map;
 
 public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
 
-  private static final String SHA256WITHRSA = "SHA256withRSA";
-  private static final String SHA512WITHRSA = "SHA512withRSA";
+  private static final String SHA256WithRSA = "SHA256withRSA";
+  private static final String SHA512WithRSA = "SHA512withRSA";
+  private static final String Digest_SHA256 = "SHA-256";
+  private static final String Digest_SHA512 = "SHA-512";
 
   private final ReactApplicationContext reactContext;
 
@@ -35,9 +37,34 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
   @Override
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
-    constants.put(SHA256WITHRSA, SHA256WITHRSA);
-    constants.put(SHA512WITHRSA, SHA512WITHRSA);
+    constants.put(SHA256WithRSA, SHA256WithRSA);
+    constants.put(SHA512WithRSA, SHA512WithRSA);
+    constants.put(Digest_SHA256, Digest_SHA256);
+    constants.put(Digest_SHA512, Digest_SHA512);
     return constants;
+  }
+
+  @ReactMethod
+  public void generateWithDigest(final String keyTag, final String digest, final Promise promise) {
+    final ReactApplicationContext reactContext = this.reactContext;
+
+    AsyncTask.execute(new Runnable() {
+      @Override
+      public void run() {
+        WritableNativeMap keys = new WritableNativeMap();
+
+        try {
+          RSA rsa = new RSA();
+          rsa.generate(keyTag, 2048, digest, reactContext);
+          keys.putString("public", rsa.getPublicKey());
+          promise.resolve(keys);
+        } catch (NoSuchAlgorithmException e) {
+          promise.reject("Error", e.getMessage());
+        } catch (Exception e) {
+          promise.reject("Error", e.getMessage());
+        }
+      }
+    });
   }
 
   @ReactMethod
@@ -56,7 +83,7 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
 
         try {
           RSA rsa = new RSA();
-          rsa.generate(keyTag, keySize, reactContext);
+          rsa.generate(keyTag, keySize, Digest_SHA512, reactContext);
           keys.putString("public", rsa.getPublicKey());
           promise.resolve(keys);
         } catch (NoSuchAlgorithmException e) {

--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -19,8 +19,6 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
 
   private static final String SHA256withRSA = "SHA256withRSA";
   private static final String SHA512withRSA = "SHA512withRSA";
-  private static final String Digest_SHA256 = "SHA-256";
-  private static final String Digest_SHA512 = "SHA-512";
 
   private final ReactApplicationContext reactContext;
 
@@ -39,32 +37,7 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
     final Map<String, Object> constants = new HashMap<>();
     constants.put(SHA256withRSA, SHA256withRSA);
     constants.put(SHA512withRSA, SHA512withRSA);
-    constants.put(Digest_SHA256, Digest_SHA256);
-    constants.put(Digest_SHA512, Digest_SHA512);
     return constants;
-  }
-
-  @ReactMethod
-  public void generateWithDigest(final String keyTag, final String digest, final Promise promise) {
-    final ReactApplicationContext reactContext = this.reactContext;
-
-    AsyncTask.execute(new Runnable() {
-      @Override
-      public void run() {
-        WritableNativeMap keys = new WritableNativeMap();
-
-        try {
-          RSA rsa = new RSA();
-          rsa.generate(keyTag, 2048, digest, reactContext);
-          keys.putString("public", rsa.getPublicKey());
-          promise.resolve(keys);
-        } catch (NoSuchAlgorithmException e) {
-          promise.reject("Error", e.getMessage());
-        } catch (Exception e) {
-          promise.reject("Error", e.getMessage());
-        }
-      }
-    });
   }
 
   @ReactMethod
@@ -83,7 +56,7 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
 
         try {
           RSA rsa = new RSA();
-          rsa.generate(keyTag, keySize, Digest_SHA512, reactContext);
+          rsa.generate(keyTag, keySize, reactContext);
           keys.putString("public", rsa.getPublicKey());
           promise.resolve(keys);
         } catch (NoSuchAlgorithmException e) {

--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -170,13 +170,13 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void sign(final String message, final String keyTag, final String signature, final Promise promise) {
+  public void sign(final String message, final String keyTag, final String algorithm, final Promise promise) {
     AsyncTask.execute(new Runnable() {
       @Override
       public void run() {
         try {
           RSA rsa = new RSA(keyTag);
-          String signature = rsa.sign(message, signature);
+          String signature = rsa.sign(message, algorithm);
           promise.resolve(signature);
 
         } catch (Exception e) {

--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -12,6 +12,8 @@ import com.facebook.react.bridge.WritableNativeMap;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
 

--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -15,6 +15,9 @@ import java.security.NoSuchAlgorithmException;
 
 public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
 
+  private static final String SHA256WITHRSA = "SHA256withRSA";
+  private static final String SHA512WITHRSA = "SHA512withRSA";
+
   private final ReactApplicationContext reactContext;
 
   public RNRSAKeychainModule(ReactApplicationContext reactContext) {
@@ -25,6 +28,14 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
   @Override
   public String getName() {
     return "RNRSAKeychain";
+  }
+
+  @Override
+  public Map<String, Object> getConstants() {
+    final Map<String, Object> constants = new HashMap<>();
+    constants.put(SHA256WITHRSA, SHA256WITHRSA);
+    constants.put(SHA512WITHRSA, SHA512WITHRSA);
+    return constants;
   }
 
   @ReactMethod
@@ -146,7 +157,24 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
       public void run() {
         try {
           RSA rsa = new RSA(keyTag);
-          String signature = rsa.sign(message);
+          String signature = rsa.sign(message, SHA512WITHRSA);
+          promise.resolve(signature);
+
+        } catch (Exception e) {
+          promise.reject("Error", e.getMessage());
+        }
+      }
+    });
+  }
+
+  @ReactMethod
+  public void sign(final String message, final String keyTag, final String signature, final Promise promise) {
+    AsyncTask.execute(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          RSA rsa = new RSA(keyTag);
+          String signature = rsa.sign(message, signature);
           promise.resolve(signature);
 
         } catch (Exception e) {

--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -170,7 +170,7 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void sign(final String message, final String keyTag, final String algorithm, final Promise promise) {
+  public void signWithAlgorithm(final String message, final String keyTag, final String algorithm, final Promise promise) {
     AsyncTask.execute(new Runnable() {
       @Override
       public void run() {

--- a/android/src/main/java/com/RNRSA/RNRSAModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAModule.java
@@ -18,8 +18,8 @@ import java.util.Map;
 
 public class RNRSAModule extends ReactContextBaseJavaModule {
 
-  private static final String SHA256WithRSA = "SHA256withRSA";
-  private static final String SHA512WithRSA = "SHA512withRSA";
+  private static final String SHA256withRSA = "SHA256withRSA";
+  private static final String SHA512withRSA = "SHA512withRSA";
 
   private final ReactApplicationContext reactContext;
 
@@ -36,8 +36,8 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
   @Override
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
-    constants.put(SHA256WithRSA, SHA256WithRSA);
-    constants.put(SHA512WithRSA, SHA512WithRSA);
+    constants.put(SHA256withRSA, SHA256withRSA);
+    constants.put(SHA512withRSA, SHA512withRSA);
     return constants;
   }
 
@@ -146,7 +146,7 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
         try {
           RSA rsa = new RSA();
           rsa.setPrivateKey(privateKeyString);
-          String signature = rsa.sign(message, SHA512WithRSA);
+          String signature = rsa.sign(message, SHA512withRSA);
           promise.resolve(signature);
 
         } catch (Exception e) {

--- a/android/src/main/java/com/RNRSA/RNRSAModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAModule.java
@@ -18,8 +18,8 @@ import java.util.Map;
 
 public class RNRSAModule extends ReactContextBaseJavaModule {
 
-  private static final String SHA256WITHRSA = "SHA256withRSA";
-  private static final String SHA512WITHRSA = "SHA512withRSA";
+  private static final String SHA256WithRSA = "SHA256withRSA";
+  private static final String SHA512WithRSA = "SHA512withRSA";
 
   private final ReactApplicationContext reactContext;
 
@@ -36,8 +36,8 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
   @Override
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
-    constants.put(SHA256WITHRSA, SHA256WITHRSA);
-    constants.put(SHA512WITHRSA, SHA512WITHRSA);
+    constants.put(SHA256WithRSA, SHA256WithRSA);
+    constants.put(SHA512WithRSA, SHA512WithRSA);
     return constants;
   }
 
@@ -146,7 +146,7 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
         try {
           RSA rsa = new RSA();
           rsa.setPrivateKey(privateKeyString);
-          String signature = rsa.sign(message, SHA512WITHRSA);
+          String signature = rsa.sign(message, SHA512WithRSA);
           promise.resolve(signature);
 
         } catch (Exception e) {

--- a/android/src/main/java/com/RNRSA/RNRSAModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAModule.java
@@ -13,8 +13,13 @@ import com.facebook.react.bridge.Promise;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RNRSAModule extends ReactContextBaseJavaModule {
+
+  private static final String SHA256WITHRSA = "SHA256withRSA";
+  private static final String SHA512WITHRSA = "SHA512withRSA";
 
   private final ReactApplicationContext reactContext;
 
@@ -26,6 +31,14 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
   @Override
   public String getName() {
     return "RNRSA";
+  }
+
+  @Override
+  public Map<String, Object> getConstants() {
+    final Map<String, Object> constants = new HashMap<>();
+    constants.put(SHA256WITHRSA, SHA256WITHRSA);
+    constants.put(SHA512WITHRSA, SHA512WITHRSA);
+    return constants;
   }
 
   @ReactMethod
@@ -133,7 +146,7 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
         try {
           RSA rsa = new RSA();
           rsa.setPrivateKey(privateKeyString);
-          String signature = rsa.sign(message);
+          String signature = rsa.sign(message, SHA512WITHRSA);
           promise.resolve(signature);
 
         } catch (Exception e) {

--- a/android/src/main/java/com/RNRSA/RNRSAModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAModule.java
@@ -157,6 +157,23 @@ public class RNRSAModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void signWithAlgorithm(final String message, final String keyTag, final String algorithm, final Promise promise) {
+    AsyncTask.execute(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          RSA rsa = new RSA(keyTag);
+          String signature = rsa.sign(message, algorithm);
+          promise.resolve(signature);
+
+        } catch (Exception e) {
+          promise.reject("Error", e.getMessage());
+        }
+      }
+    });
+  }
+
+  @ReactMethod
   public void sign64(final String message, final String privateKeyString, final Promise promise) {
     AsyncTask.execute(new Runnable() {
       @Override

--- a/android/src/main/java/com/RNRSA/RNRSAPackage.java
+++ b/android/src/main/java/com/RNRSA/RNRSAPackage.java
@@ -18,11 +18,6 @@ public class RNRSAPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -1,14 +1,11 @@
 package com.RNRSA;
 
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.security.KeyPairGeneratorSpec;
 
 import android.util.Base64;
-import android.util.Log;
 import android.content.Context;
 
 import java.util.Calendar;
@@ -30,10 +27,8 @@ import java.security.InvalidKeyException;
 import java.security.Signature;
 import java.security.SignatureException;
 import java.security.UnrecoverableEntryException;
-import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.spec.X509EncodedKeySpec;
-import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.RSAPrivateKeySpec;
 import java.security.spec.InvalidKeySpecException;
 
@@ -295,10 +290,13 @@ public class RSA {
     }
 
     public void generate(String keyTag, Context context) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException {
-        this.generate(keyTag, 2048, context);
+        this.generate(keyTag, 2048, null, context);
     }
 
-    public void generate(String keyTag, int keySize, Context context) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException {
+    public void generate(String keyTag, int keySize, String digest, Context context) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException {
+        if (digest == null || digest.isEmpty()) {
+            digest = DIGEST_SHA512;
+        }
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(ALGORITHM, "AndroidKeyStore");
         if (android.os.Build.VERSION.SDK_INT >= 23) {
             kpg.initialize(
@@ -307,7 +305,7 @@ public class RSA {
                     PURPOSE_ENCRYPT | PURPOSE_DECRYPT | PURPOSE_SIGN | PURPOSE_VERIFY
                 )
                 .setKeySize(keySize)
-                .setDigests(DIGEST_SHA256, DIGEST_SHA512)
+                .setDigests(digest)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
                 .setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1)
                 .build()

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -307,7 +307,7 @@ public class RSA {
                     PURPOSE_ENCRYPT | PURPOSE_DECRYPT | PURPOSE_SIGN | PURPOSE_VERIFY
                 )
                 .setKeySize(keySize)
-                .setDigests(KeyProperties.DIGEST_SHA512)
+                .setDigests(DIGEST_SHA256, DIGEST_SHA512)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
                 .setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1)
                 .build()

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -290,13 +290,11 @@ public class RSA {
     }
 
     public void generate(String keyTag, Context context) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException {
-        this.generate(keyTag, 2048, null, context);
+        this.generate(keyTag, 2048, context);
     }
 
-    public void generate(String keyTag, int keySize, String digest, Context context) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException {
-        if (digest == null || digest.isEmpty()) {
-            digest = DIGEST_SHA512;
-        }
+    public void generate(String keyTag, int keySize, Context context) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException {
+
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(ALGORITHM, "AndroidKeyStore");
         if (android.os.Build.VERSION.SDK_INT >= 23) {
             kpg.initialize(
@@ -305,7 +303,7 @@ public class RSA {
                     PURPOSE_ENCRYPT | PURPOSE_DECRYPT | PURPOSE_SIGN | PURPOSE_VERIFY
                 )
                 .setKeySize(keySize)
-                .setDigests(digest)
+                .setDigests(DIGEST_SHA256, DIGEST_SHA512)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
                 .setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1)
                 .build()

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -164,8 +164,8 @@ public class RSA {
         return Base64.encodeToString(data, Base64.DEFAULT);
     }
 
-    private String sign(byte[] messageBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
-        Signature privateSignature = Signature.getInstance("SHA512withRSA");
+    private String sign(byte[] messageBytes, String signature) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+        Signature privateSignature = Signature.getInstance(signature);
         privateSignature.initSign(this.privateKey);
         privateSignature.update(messageBytes);
         byte[] signature = privateSignature.sign();
@@ -179,9 +179,9 @@ public class RSA {
     }
 
     //utf-8 message
-    public String sign(String message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+    public String sign(String message, String signature) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
         byte[] messageBytes = message.getBytes(CharsetUTF_8);
-        return sign(messageBytes);
+        return sign(messageBytes, signature);
     }
 
     private boolean verify(byte[] signatureBytes, byte[] messageBytes) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -164,8 +164,8 @@ public class RSA {
         return Base64.encodeToString(data, Base64.DEFAULT);
     }
 
-    private String sign(byte[] messageBytes, String signature) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
-        Signature privateSignature = Signature.getInstance(signature);
+    private String sign(byte[] messageBytes, String algorithm) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
+        Signature privateSignature = Signature.getInstance(algorithm);
         privateSignature.initSign(this.privateKey);
         privateSignature.update(messageBytes);
         byte[] signature = privateSignature.sign();
@@ -175,7 +175,7 @@ public class RSA {
     // b64 message
     public String sign64(String b64message) throws NoSuchAlgorithmException, InvalidKeySpecException, IllegalBlockSizeException, BadPaddingException, NoSuchPaddingException, InvalidKeyException, SignatureException {
         byte[] messageBytes = Base64.decode(b64message, Base64.DEFAULT);
-        return sign(messageBytes);
+        return sign(messageBytes, "SHA512WithRSA");
     }
 
     //utf-8 message

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,9 @@ declare module 'react-native-rsa-native' {
 	}
 
 	namespace RSAKeychain {
+		export function generate(keyTag: string, keySize: number): Promise<PublicKey>;
 		export function generateKeys(keyTag: string, keySize: number): Promise<PublicKey>;
+		export function generateWithDigest(keyTag: string, digest: string): Promise<PublicKey>;
 		export function deletePrivateKey(keyTag: string): Promise<boolean>;
 		export function encrypt(data: string, keyTag: string): Promise<string>;
 		export function decrypt(data: string, keyTag: string): Promise<string>;
@@ -26,6 +28,8 @@ declare module 'react-native-rsa-native' {
 		export function getPublicKey(keyTag: string): Promise<string | undefined>;
 		export const SHA256WithRSA: string;
 		export const SHA512WithRSA: string;
+		export const Digest_SHA256: string;
+		export const Digest_SHA512: string;
 	}
 
 	export { RSA, RSAKeychain };

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare module 'react-native-rsa-native' {
 		export function encrypt(data: string, keyTag: string): Promise<string>;
 		export function decrypt(data: string, keyTag: string): Promise<string>;
 		export function sign(data: string, keyTag: string): Promise<string>;
-		export function sign(data: string, keyTag: string, signature?: 'SHA256withRSA' | 'SHA512withRSA'): Promise<string>;
+		export function signWithAlgorithm(data: string, keyTag: string, signature?: 'SHA256withRSA' | 'SHA512withRSA'): Promise<string>;
 		export function verify(data: string, secretToVerify: string, keyTag: string): Promise<boolean>;
 		export function getPublicKey(keyTag: string): Promise<string | undefined>;
 		export const SHA256withRSA: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,11 +8,15 @@ declare module 'react-native-rsa-native' {
 	}
 
 	namespace RSA {
+		export function generate(keySize: number): Promise<PublicKey>;
 		export function generateKeys(keySize: number): Promise<KeyPair>;
 		export function encrypt(data: string, key: string): Promise<string>;
 		export function decrypt(data: string, key: string): Promise<string>;
 		export function sign(data: string, key: string): Promise<string>;
+		export function signWithAlgorithm(data: string, key: string, signature?: 'SHA256withRSA' | 'SHA512withRSA'): Promise<string>;
 		export function verify(data: string, secretToVerify: string, key: string): Promise<boolean>;
+		export const SHA256withRSA: string;
+		export const SHA512withRSA: string;
 	}
 
 	namespace RSAKeychain {

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,6 @@ declare module 'react-native-rsa-native' {
 	namespace RSAKeychain {
 		export function generate(keyTag: string, keySize: number): Promise<PublicKey>;
 		export function generateKeys(keyTag: string, keySize: number): Promise<PublicKey>;
-		export function generateWithDigest(keyTag: string, digest: string): Promise<PublicKey>;
 		export function deletePrivateKey(keyTag: string): Promise<boolean>;
 		export function encrypt(data: string, keyTag: string): Promise<string>;
 		export function decrypt(data: string, keyTag: string): Promise<string>;
@@ -28,8 +27,6 @@ declare module 'react-native-rsa-native' {
 		export function getPublicKey(keyTag: string): Promise<string | undefined>;
 		export const SHA256withRSA: string;
 		export const SHA512withRSA: string;
-		export const Digest_SHA256: string;
-		export const Digest_SHA512: string;
 	}
 
 	export { RSA, RSAKeychain };

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,8 +24,8 @@ declare module 'react-native-rsa-native' {
 		export function sign(data: string, keyTag: string, signature?: 'SHA256WithRSA' | 'SHA512WithRSA'): Promise<string>;
 		export function verify(data: string, secretToVerify: string, keyTag: string): Promise<boolean>;
 		export function getPublicKey(keyTag: string): Promise<string | undefined>;
-		export const SHA256WITHRSA: string;
-		export const SHA512WITHRSA: string;
+		export const SHA256WithRSA: string;
+		export const SHA512WithRSA: string;
 	}
 
 	export { RSA, RSAKeychain };

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare module 'react-native-rsa-native' {
 		export function encrypt(data: string, keyTag: string): Promise<string>;
 		export function decrypt(data: string, keyTag: string): Promise<string>;
 		export function sign(data: string, keyTag: string): Promise<string>;
+		export function sign(data: string, keyTag: string, signature?: 'SHA256WithRSA' | 'SHA512WithRSA'): Promise<string>;
 		export function verify(data: string, secretToVerify: string, keyTag: string): Promise<boolean>;
 		export function getPublicKey(keyTag: string): Promise<string | undefined>;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,11 +23,11 @@ declare module 'react-native-rsa-native' {
 		export function encrypt(data: string, keyTag: string): Promise<string>;
 		export function decrypt(data: string, keyTag: string): Promise<string>;
 		export function sign(data: string, keyTag: string): Promise<string>;
-		export function sign(data: string, keyTag: string, signature?: 'SHA256WithRSA' | 'SHA512WithRSA'): Promise<string>;
+		export function sign(data: string, keyTag: string, signature?: 'SHA256withRSA' | 'SHA512withRSA'): Promise<string>;
 		export function verify(data: string, secretToVerify: string, keyTag: string): Promise<boolean>;
 		export function getPublicKey(keyTag: string): Promise<string | undefined>;
-		export const SHA256WithRSA: string;
-		export const SHA512WithRSA: string;
+		export const SHA256withRSA: string;
+		export const SHA512withRSA: string;
 		export const Digest_SHA256: string;
 		export const Digest_SHA512: string;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,8 @@ declare module 'react-native-rsa-native' {
 		export function sign(data: string, keyTag: string, signature?: 'SHA256WithRSA' | 'SHA512WithRSA'): Promise<string>;
 		export function verify(data: string, secretToVerify: string, keyTag: string): Promise<boolean>;
 		export function getPublicKey(keyTag: string): Promise<string | undefined>;
+		export const SHA256WITHRSA: string;
+		export const SHA512WITHRSA: string;
 	}
 
 	export { RSA, RSAKeychain };

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 
 import { NativeModules } from 'react-native';
 
-const { RNRSAKeychain } = NativeModules;
-const { RNRSA } = NativeModules;
-RNRSAKeychain.Digest_SHA256=RNRSAKeychain['SHA-256'];
-RNRSAKeychain.Digest_SHA512=RNRSAKeychain['SHA-512'];
+const { RNRSAKeychain, RNRSA } = NativeModules;
+
 export { RNRSAKeychain, RNRSAKeychain as RSAKeychain, RNRSA, RNRSA as RSA };
 
 export default RNRSA;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ import { NativeModules } from 'react-native';
 
 const { RNRSAKeychain } = NativeModules;
 const { RNRSA } = NativeModules;
-
+RNRSAKeychain.Digest_SHA256=RNRSAKeychain['SHA-256'];
+RNRSAKeychain.Digest_SHA512=RNRSAKeychain['SHA-512'];
 export { RNRSAKeychain, RNRSAKeychain as RSAKeychain, RNRSA, RNRSA as RSA };
 
 export default RNRSA;

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -87,7 +87,7 @@ RCT_EXPORT_METHOD(sign:(NSString *)message withKey:(NSString *)key resolve:(RCTP
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RSANative *rsa = [[RSANative alloc] init];
         rsa.privateKey = key;
-        NSString *signature = [rsa sign:message withAlgorithm: @"SHA512withRSA"];
+        NSString *signature = [rsa sign:message withAlgorithm: @"SHA512withRSA" withEncodeOption: NSDataBase64Encoding64CharacterLineLength];
         resolve(signature);
     });
 }
@@ -202,7 +202,7 @@ RCT_EXPORT_METHOD(signWithAlgorithm:(NSString *)message withKeyTag:(NSString *)k
                   rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-        NSString *signature = [rsa sign:message withAlgorithm: algorithm];
+        NSString *signature = [rsa sign:message withAlgorithm: algorithm withEncodeOption: 0];
         resolve(signature);
     });
 }
@@ -211,7 +211,7 @@ RCT_EXPORT_METHOD(sign:(NSString *)message withKeyTag:(NSString *)keyTag resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-        NSString *signature = [rsa sign:message withAlgorithm: @"SHA512withRSA"];
+        NSString *signature = [rsa sign:message withAlgorithm: @"SHA512withRSA" withEncodeOption: NSDataBase64Encoding64CharacterLineLength];
         resolve(signature);
     });
 }

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -27,7 +27,7 @@ RCT_EXPORT_METHOD(generateKeys:(int)keySize resolve:(RCTPromiseResolveBlock)reso
                   rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RSANative *rsa = [[RSANative alloc] init];
-        [rsa generate:keySize];
+        [rsa generate:keySize withDigest: @"Digest_SHA512"];
         NSDictionary *keys = @{
                             @"private" : [rsa encodedPrivateKey],
                             @"public" : [rsa encodedPublicKey]
@@ -142,7 +142,7 @@ RCT_EXPORT_METHOD(generateWithDigest:(NSString *)keyTag digest:(NSString *)diges
                   rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-        [rsa generate:keySize withDigest: digest];
+        [rsa generate:2048 withDigest: digest];
         NSDictionary *keys = @{@"public" : [rsa encodedPublicKey]};
         resolve(keys);
     });
@@ -157,7 +157,7 @@ RCT_EXPORT_METHOD(generateKeys:(NSString *)keyTag keySize:(int)keySize resolve:(
                   rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-        [rsa generate:keySize];
+        [rsa generate:keySize withDigest: @"Digest_SHA512"];
         NSDictionary *keys = @{@"public" : [rsa encodedPublicKey]};
         resolve(keys);
     });

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -7,6 +7,11 @@
     return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_MODULE()
 
 - (NSDictionary *)constantsToExport
@@ -123,6 +128,11 @@ RCT_EXPORT_METHOD(verify64:(NSString *)signature withMessage:(NSString *)message
 
 - (dispatch_queue_t)methodQueue {
     return dispatch_get_main_queue();
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
 }
 
 RCT_EXPORT_MODULE()

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -9,7 +9,7 @@
 
 + (BOOL)requiresMainQueueSetup
 {
-    return YES;
+    return NO;
 }
 
 RCT_EXPORT_MODULE()
@@ -132,7 +132,7 @@ RCT_EXPORT_METHOD(verify64:(NSString *)signature withMessage:(NSString *)message
 
 + (BOOL)requiresMainQueueSetup
 {
-    return YES;
+    return NO;
 }
 
 RCT_EXPORT_MODULE()

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -32,7 +32,7 @@ RCT_EXPORT_METHOD(generateKeys:(int)keySize resolve:(RCTPromiseResolveBlock)reso
                   rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RSANative *rsa = [[RSANative alloc] init];
-        [rsa generate:keySize withDigest: @"Digest_SHA512"];
+        [rsa generate:keySize];
         NSDictionary *keys = @{
                             @"private" : [rsa encodedPrivateKey],
                             @"public" : [rsa encodedPublicKey]
@@ -141,22 +141,10 @@ RCT_EXPORT_MODULE()
 {
     return @{
              @"SHA256withRSA": @"SHA256withRSA",
-             @"SHA512withRSA": @"SHA512withRSA",
-             @"Digest_SHA256": @"SHA-256",
-             @"Digest_SHA512": @"SHA-512"
+             @"SHA512withRSA": @"SHA512withRSA"
             };
 }
 // Keychain based API, provide a key chain tag with each call
-
-RCT_EXPORT_METHOD(generateWithDigest:(NSString *)keyTag digest:(NSString *)digest resolve:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-        [rsa generate:2048 withDigest: digest];
-        NSDictionary *keys = @{@"public" : [rsa encodedPublicKey]};
-        resolve(keys);
-    });
-}
 
 RCT_EXPORT_METHOD(generate:(NSString *)keyTag resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
@@ -167,7 +155,7 @@ RCT_EXPORT_METHOD(generateKeys:(NSString *)keyTag keySize:(int)keySize resolve:(
                   rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-        [rsa generate:keySize withDigest: @"Digest_SHA512"];
+        [rsa generate:keySize];
         NSDictionary *keys = @{@"public" : [rsa encodedPublicKey]};
         resolve(keys);
     });

--- a/ios/RNRSA.m
+++ b/ios/RNRSA.m
@@ -12,8 +12,8 @@ RCT_EXPORT_MODULE()
 - (NSDictionary *)constantsToExport
 {
     return @{
-             @"SHA256WithRSA": @"SHA256WithRSA",
-             @"SHA512WithRSA": @"SHA512WithRSA"
+             @"SHA256withRSA": @"SHA256withRSA",
+             @"SHA512withRSA": @"SHA512withRSA"
              };
 }
 // Key based API, provide the public or private key with each call - pending discussions with @amitaymolko
@@ -82,7 +82,7 @@ RCT_EXPORT_METHOD(sign:(NSString *)message withKey:(NSString *)key resolve:(RCTP
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RSANative *rsa = [[RSANative alloc] init];
         rsa.privateKey = key;
-        NSString *signature = [rsa sign:message withAlgorithm: @"SHA512WithRSA"];
+        NSString *signature = [rsa sign:message withAlgorithm: @"SHA512withRSA"];
         resolve(signature);
     });
 }
@@ -130,8 +130,8 @@ RCT_EXPORT_MODULE()
 - (NSDictionary *)constantsToExport
 {
     return @{
-             @"SHA256WithRSA": @"SHA256WithRSA",
-             @"SHA512WithRSA": @"SHA512WithRSA",
+             @"SHA256withRSA": @"SHA256withRSA",
+             @"SHA512withRSA": @"SHA512withRSA",
              @"Digest_SHA256": @"SHA-256",
              @"Digest_SHA512": @"SHA-512"
             };
@@ -201,7 +201,7 @@ RCT_EXPORT_METHOD(sign:(NSString *)message withKeyTag:(NSString *)keyTag resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RSANative *rsa = [[RSANative alloc] initWithKeyTag:keyTag];
-        NSString *signature = [rsa sign:message withAlgorithm: @"SHA512WithRSA"];
+        NSString *signature = [rsa sign:message withAlgorithm: @"SHA512withRSA"];
         resolve(signature);
     });
 }

--- a/ios/RSANative.h
+++ b/ios/RSANative.h
@@ -15,7 +15,7 @@
 
 - (instancetype)initWithKeyTag:(NSString *)keyTag;
 
-- (void)generate:(int)keySize;
+- (void)generate:(int)keySize withDigest:(NSString *)digest;
 - (void)deletePrivateKey;
 
 - (NSString *)encodedPublicKey;
@@ -30,7 +30,7 @@
 - (NSData *)_encrypt:(NSData *)message;
 - (NSData *)_decrypt:(NSData *)encodedMessage;
 
-- (NSString *)sign:(NSString *)message;
+- (NSString *)sign:(NSString *)message withAlgorithm:(NSString *)algorithm;
 - (BOOL)verify:(NSString *)signature withMessage:(NSString *)message;
 
 - (NSString *)sign64:(NSString *)b64message;

--- a/ios/RSANative.h
+++ b/ios/RSANative.h
@@ -15,7 +15,7 @@
 
 - (instancetype)initWithKeyTag:(NSString *)keyTag;
 
-- (void)generate:(int)keySize withDigest:(NSString *)digest;
+- (void)generate:(int)keySize;
 - (void)deletePrivateKey;
 
 - (NSString *)encodedPublicKey;

--- a/ios/RSANative.h
+++ b/ios/RSANative.h
@@ -30,7 +30,7 @@
 - (NSData *)_encrypt:(NSData *)message;
 - (NSData *)_decrypt:(NSData *)encodedMessage;
 
-- (NSString *)sign:(NSString *)message withAlgorithm:(NSString *)algorithm;
+- (NSString *)sign:(NSString *)message withAlgorithm:(NSString *)algorithm withEncodeOption: (NSDataBase64EncodingOptions)encodeOption;
 - (BOOL)verify:(NSString *)signature withMessage:(NSString *)message;
 
 - (NSString *)sign64:(NSString *)b64message;

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -22,7 +22,7 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
     return self;
 }
 
-- (void)generate:(int)keySize {
+- (void)generate:(int)keySize withDigest:(NSString *)digest {
     NSMutableDictionary *privateKeyAttributes = [NSMutableDictionary dictionary];
 
     if (self.keyTag) {
@@ -215,21 +215,21 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 
 - (NSString *)sign64:(NSString *)b64message {
     NSData *data = [[NSData alloc] initWithBase64EncodedString:b64message options:NSDataBase64DecodingIgnoreUnknownCharacters];
-    NSString *encodedSignature = [self _sign: data];
+    NSString *encodedSignature = [self _sign: data withAlgorithm: @"SHA512WithRSA"];
     return encodedSignature;
 }
 
-- (NSString *)sign:(NSString *)message {
+- (NSString *)sign:(NSString *)message withAlgorithm:(NSString *)algorithm {
     NSData* data = [message dataUsingEncoding:NSUTF8StringEncoding];
-    NSString *encodedSignature = [self _sign: data];
+    NSString *encodedSignature = [self _sign: data withAlgorithm:algorithm];
     return encodedSignature;
 }
 
-- (NSString *)_sign:(NSData *)messageBytes {
+- (NSString *)_sign:(NSData *)messageBytes withAlgorithm:(NSString *)signAlgorithm {
     __block NSString *encodedSignature = nil;
 
     void(^signer)(SecKeyRef) = ^(SecKeyRef privateKey) {
-        SecKeyAlgorithm algorithm = kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA512;
+        SecKeyAlgorithm algorithm = [signAlgorithm isEqualToString: @"SHA256WithRSA"] ? kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256 : kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA512;
 
         BOOL canSign = SecKeyIsAlgorithmSupported(privateKey,
                                                 kSecKeyOperationTypeSign,

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -22,7 +22,7 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
     return self;
 }
 
-- (void)generate:(int)keySize withDigest:(NSString *)digest {
+- (void)generate:(int)keySize {
     NSMutableDictionary *privateKeyAttributes = [NSMutableDictionary dictionary];
 
     if (self.keyTag) {

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -215,17 +215,17 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 
 - (NSString *)sign64:(NSString *)b64message {
     NSData *data = [[NSData alloc] initWithBase64EncodedString:b64message options:NSDataBase64DecodingIgnoreUnknownCharacters];
-    NSString *encodedSignature = [self _sign: data withAlgorithm: @"SHA512withRSA"];
+    NSString *encodedSignature = [self _sign: data withAlgorithm: @"SHA512withRSA" withEncodeOption: NSDataBase64Encoding64CharacterLineLength];
     return encodedSignature;
 }
 
-- (NSString *)sign:(NSString *)message withAlgorithm:(NSString *)algorithm {
+- (NSString *)sign:(NSString *)message withAlgorithm:(NSString *)algorithm withEncodeOption: (NSDataBase64EncodingOptions)encodeOption{
     NSData* data = [message dataUsingEncoding:NSUTF8StringEncoding];
-    NSString *encodedSignature = [self _sign: data withAlgorithm:algorithm];
+    NSString *encodedSignature = [self _sign: data withAlgorithm:algorithm withEncodeOption: encodeOption];
     return encodedSignature;
 }
 
-- (NSString *)_sign:(NSData *)messageBytes withAlgorithm:(NSString *)signAlgorithm {
+- (NSString *)_sign:(NSData *)messageBytes withAlgorithm:(NSString *)signAlgorithm withEncodeOption: (NSDataBase64EncodingOptions)encodeOption {
     __block NSString *encodedSignature = nil;
 
     void(^signer)(SecKeyRef) = ^(SecKeyRef privateKey) {
@@ -248,8 +248,8 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
               NSLog(@"error: %@", err);
             }
         }
-
-        encodedSignature = [signature base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+        
+        encodedSignature = [signature base64EncodedStringWithOptions: encodeOption];
     };
 
     if (self.keyTag) {

--- a/ios/RSANative.m
+++ b/ios/RSANative.m
@@ -215,7 +215,7 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
 
 - (NSString *)sign64:(NSString *)b64message {
     NSData *data = [[NSData alloc] initWithBase64EncodedString:b64message options:NSDataBase64DecodingIgnoreUnknownCharacters];
-    NSString *encodedSignature = [self _sign: data withAlgorithm: @"SHA512WithRSA"];
+    NSString *encodedSignature = [self _sign: data withAlgorithm: @"SHA512withRSA"];
     return encodedSignature;
 }
 
@@ -229,7 +229,7 @@ typedef void (^SecKeyPerformBlock)(SecKeyRef key);
     __block NSString *encodedSignature = nil;
 
     void(^signer)(SecKeyRef) = ^(SecKeyRef privateKey) {
-        SecKeyAlgorithm algorithm = [signAlgorithm isEqualToString: @"SHA256WithRSA"] ? kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256 : kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA512;
+        SecKeyAlgorithm algorithm = [signAlgorithm isEqualToString: @"SHA256withRSA"] ? kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256 : kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA512;
 
         BOOL canSign = SecKeyIsAlgorithmSupported(privateKey,
                                                 kSecKeyOperationTypeSign,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-rsa-native",
-  "version": "1.0.24",
+  "version": "2.0.0",
   "description": "A native implementation of RSA key generation and encryption/decryption.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-rsa-native",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "A native implementation of RSA key generation and encryption/decryption.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
The current sign method was hard coded with SHA512withRSA algorithm. Have added a new method signWithAlgorithm with support for SHA256 and SHA512 algorithm.

In order for the SHA256 algorithm to work for signing, the user needs to generate a new keypair on RSAKeychain. (Have added SHA256 and SHA512 digest for creating rsa keys on android version 23 and up)

This merge also have updated the android build tools to 28.0.0.