### PR TITLE
Podspec iOS version to minimum iOS 10

### DIFF
--- a/react-native-rsa-native.podspec
+++ b/react-native-rsa-native.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.homepage     = package["homepage"]
   s.license      = package["license"]
   s.authors      = package["author"]["name"]
-  s.platforms    = { :ios => "7.0", :tvos => "9.0" }
+  s.platforms    = { :ios => "10.0", :tvos => "10.0" }
   s.source       = { :git => package["repository"]["url"], :tag => "#{s.version}" }
   s.source_files = "ios/**/*.{h,m}"
 


### PR DESCRIPTION
Hi @amitaymolko,

Mate hope all is going well.

Minor patch here to update the projects podspec to specify iOS 10 as a minimum given the use of SecKey*… API's which are iOS 10 and above. This also sorts out a lot of warnings currently shown about this in Xcode.

Cheers mate. All the best!