### PR TITLE
add verifyToAlgorithm to ts type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ declare module 'react-native-rsa-native' {
 		export function sign(data: string, key: string): Promise<string>;
 		export function signWithAlgorithm(data: string, key: string, signature?: 'SHA256withRSA' | 'SHA512withRSA'): Promise<string>;
 		export function verify(data: string, secretToVerify: string, key: string): Promise<boolean>;
+		export function verifyWithAlgorithm(data: string, secretToVerify: string, key: string, signature?: 'SHA256withRSA' | 'SHA512withRSA'): Promise<boolean>;
 		export const SHA256withRSA: string;
 		export const SHA512withRSA: string;
 	}
@@ -28,6 +29,7 @@ declare module 'react-native-rsa-native' {
 		export function sign(data: string, keyTag: string): Promise<string>;
 		export function signWithAlgorithm(data: string, keyTag: string, signature?: 'SHA256withRSA' | 'SHA512withRSA'): Promise<string>;
 		export function verify(data: string, secretToVerify: string, keyTag: string): Promise<boolean>;
+		export function verifyWithAlgorithm(data: string, secretToVerify: string, keyTag: string, signature?: 'SHA256withRSA' | 'SHA512withRSA'): Promise<boolean>;
 		export function getPublicKey(keyTag: string): Promise<string | undefined>;
 		export const SHA256withRSA: string;
 		export const SHA512withRSA: string;


### PR DESCRIPTION
This adds type definitions for the corresponding native methods:

[`RSA.verifyWithAlgorithm`](https://github.com/amitaymolko/react-native-rsa-native/blob/1.1.2/ios/RNRSA.m#L137)

[`RSAKeychain.verifyWithAlgorithm`](https://github.com/amitaymolko/react-native-rsa-native/blob/1.1.2/ios/RNRSA.m#L259)