### PR TITLE
Export additional types within Typescript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare module 'react-native-rsa-native' {
 	interface KeyPair extends PublicKey {
 		private: string;
 	}
+
 	type TypeCrypto  = 
 		'SHA256withRSA'|
 		'SHA512withRSA'|

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,5 +72,5 @@ declare module 'react-native-rsa-native' {
 		export const SHA1withECDSA: string;
 	}
 
-	export { RSA, RSAKeychain };
+	export { RSA, RSAKeychain, KeyPair, CSRKey };
 }


### PR DESCRIPTION
Some methods (e.g. `RSA.generateKeys`, `RSAKeychain.generateCSR`) use custom return types which are not currently exported for external modules to reference. 

This PR exports a number of types for external modules to use. Specifically, 
- KeyPair
- CSRKey