### PR TITLE
Add RSA Signed CSR Generation on Android and fix iOS CSR generation crash for larger key sizes

### DIFF
--- a/android/src/main/java/com/RNRSA/CsrHelper.java
+++ b/android/src/main/java/com/RNRSA/CsrHelper.java
@@ -101,11 +101,11 @@ public class CsrHelper {
     }
 
     //Create the certificate signing request (CSR) from private and public keys
-    public static PKCS10CertificationRequest generateCSR(PublicKey publicKey, String cn, String keyTag) throws IOException,
+    public static PKCS10CertificationRequest generateCSR(PublicKey publicKey, String cn, String keyTag, String withAlgorithm) throws IOException,
             OperatorCreationException {
 
         String principal = String.format(CN_PATTERN, cn);
-        ContentSigner signer = new JCESigner (DEFAULT_SIGNATURE_ALGORITHM, keyTag);
+        ContentSigner signer = new JCESigner(withAlgorithm, keyTag);
         PKCS10CertificationRequestBuilder csrBuilder = new JcaPKCS10CertificationRequestBuilder(
                 new X500Name(principal), publicKey);
 
@@ -116,6 +116,10 @@ public class CsrHelper {
                 extensionsGenerator.generate());
         PKCS10CertificationRequest csr = csrBuilder.build(signer);
         return csr;
+    }
+
+    public static PKCS10CertificationRequest generateCSRWithEC(PublicKey publicKey, String commonName, String keyTag) throws IOException, OperatorCreationException {
+        return generateCSR(publicKey, commonName, keyTag, DEFAULT_SIGNATURE_ALGORITHM);
     }
 }
 

--- a/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
+++ b/android/src/main/java/com/RNRSA/RNRSAKeychainModule.java
@@ -71,6 +71,29 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void generateCSR(final String keyTag, final String commonName, final String withAlgorithm, final Promise promise) {
+    final ReactApplicationContext reactContext = this.reactContext;
+
+    AsyncTask.execute(new Runnable() {
+      @Override
+      public void run() {
+        WritableNativeMap keys = new WritableNativeMap();
+
+        try {
+          RSA rsa = new RSA(keyTag);
+          rsa.generateCSR(commonName, withAlgorithm, reactContext);
+          keys.putString("csr", rsa.getCSR());
+          promise.resolve(keys);
+        } catch (NoSuchAlgorithmException e) {
+          promise.reject("Error", e.getMessage());
+        } catch (Exception e) {
+          promise.reject("Error", e.getMessage());
+        }
+      }
+    });
+  }
+
+  @ReactMethod
   public void generateCSRWithEC(final String cn,final String keyTag, final int keySize, final Promise promise) {
     final ReactApplicationContext reactContext = this.reactContext;
 
@@ -81,7 +104,7 @@ public class RNRSAKeychainModule extends ReactContextBaseJavaModule {
 
         try {
           RSA rsa = new RSA();
-          rsa.generateCSR(cn,keyTag, keySize, reactContext);
+          rsa.generateCSRWithEC(cn,keyTag, keySize, reactContext);
           keys.putString("csr", rsa.getCSR());
           promise.resolve(keys);
         } catch (NoSuchAlgorithmException e) {

--- a/android/src/main/java/com/RNRSA/RSA.java
+++ b/android/src/main/java/com/RNRSA/RSA.java
@@ -345,7 +345,12 @@ public class RSA {
     }
 
     @TargetApi(18)
-    public void generateCSR(String cn,String keyTag, int keySize, Context context) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException, UnrecoverableEntryException, KeyStoreException, CertificateException {
+    public void generateCSR(String commonName, String withAlgorithm, Context context) throws IOException, OperatorCreationException {
+        this.csr = CsrHelper.generateCSR(this.publicKey, commonName, keyTag, withAlgorithm);
+    }
+
+    @TargetApi(18)
+    public void generateCSRWithEC(String cn,String keyTag, int keySize, Context context) throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException, UnrecoverableEntryException, KeyStoreException, CertificateException {
         this.deletePrivateKey();
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC, "AndroidKeyStore");
         if (android.os.Build.VERSION.SDK_INT >= 23) {
@@ -383,7 +388,7 @@ public class RSA {
         this.publicKey = keyPair.getPublic();
 
         try {
-            this.csr = CsrHelper.generateCSR(this.publicKey, cn, keyTag);
+            this.csr = CsrHelper.generateCSRWithEC(this.publicKey, cn, keyTag);
         } catch (OperatorCreationException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Does two things:

- Fix a crash on iOS when generating CSR with RSA key sizes > 2048
- Adds the missing `generateCSR` method on Android.

The iOS crash was because of a heap overrun. I changed it so that the signature is written to a `Data` object and it would allocate space as needed.

For Android, I changed the `CsrHelper.generateCSR` method to accept the algorithm to use. The old `generateCSRWithEC` method should work like it did before. Is there a reason why it was not there before? I can make changes if necessary, but I need the method for something I am working on.