### PR TITLE
ios fixes to verify methods

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -35,6 +35,12 @@ const signDemo = async () => {
   console.log('signature', signature);
   const valid = await RSA.verify(signature, secret, keys.public)
   console.log('verified', valid);
+  try {
+    await RSA.verify(signature, "wrong message", keys.public)
+    console.log("NOTE!! Something went wrong, verify should have been failed")
+  } catch (err) {
+    console.log('verify fails correctly: ', err);
+  }
 }
 
 const signAlgoDemo = async () => {
@@ -44,6 +50,12 @@ const signAlgoDemo = async () => {
   console.log('signature', signature);
   const valid = await RSA.verifyWithAlgorithm(signature, secret, keys.public, RSA.SHA256withRSA)
   console.log('verified', valid);
+  try {
+    await RSA.verifyWithAlgorithm(signature, "wrong message", keys.public, RSA.SHA256withRSA)
+    console.log("NOTE!! Something went wrong, verify should have been failed")
+  } catch (err) {
+    console.log('verify fails correctly: ', err);
+  }
 }
 
 const iosDemo = async () => {

--- a/ios/RNRSA.swift
+++ b/ios/RNRSA.swift
@@ -105,9 +105,9 @@ class RNRSA: NSObject {
             resolve(false)
             return
         }
-        let signature = rsa_ec.verify(encodedSignature: signature, withMessage: withMessage, withAlgorithm: "SHA512withRSA")
-        if(signature == nil){
-            reject("not sign it", "error", nil)
+        let verifyResult = rsa_ec.verify(encodedSignature: signature, withMessage: withMessage, withAlgorithm: "SHA512withRSA")
+        if(verifyResult == false){
+            reject("verify failed", "error", nil)
         }else {
             resolve(true)
         }
@@ -117,12 +117,14 @@ class RNRSA: NSObject {
     func verifyWithAlgorithm(_ signature: String, withMessage: String ,withKey: String, withAlgorithm: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
         let rsa_ec = RSAECNative()
         guard let _ = rsa_ec.setPublicKey(publicKey: withKey) else {
+            print("public key set failed")
             resolve(false)
             return
         }
-        let signature = rsa_ec.verify(encodedSignature: signature, withMessage: withMessage, withAlgorithm: withAlgorithm)
-        if(signature == nil){
-            reject("not sign it", "error", nil)
+        let verifyResult = rsa_ec.verify(encodedSignature: signature, withMessage: withMessage, withAlgorithm: withAlgorithm)
+        if(verifyResult == false){
+            print("verify failed")
+            reject("verify failed", "error", nil)
         }else {
             resolve(true)
         }
@@ -136,9 +138,9 @@ class RNRSA: NSObject {
             resolve(false)
             return
         }
-        let signature = rsa_ec.verify64(encodedSignature: signature, withMessage: withMessage, withAlgorithm: "SHA512withRSA")
-        if(signature == nil){
-            reject("not sign it", "error", nil)
+        let verifyResult = rsa_ec.verify64(encodedSignature: signature, withMessage: withMessage, withAlgorithm: "SHA512withRSA")
+        if(verifyResult == false){
+            reject("verify failed", "error", nil)
         }else {
             resolve(true)
         }
@@ -151,9 +153,9 @@ class RNRSA: NSObject {
             resolve(false)
             return
         }
-        let signature = rsa_ec.verify64(encodedSignature: signature, withMessage: withMessage, withAlgorithm: withAlgorithm)
-        if(signature == nil){
-            reject("not sign it", "error", nil)
+        let verifyResult = rsa_ec.verify64(encodedSignature: signature, withMessage: withMessage, withAlgorithm: withAlgorithm)
+        if(verifyResult == false){
+            reject("verify failed", "error", nil)
         }else {
             resolve(true)
         }

--- a/ios/RNRSAKeychain.swift
+++ b/ios/RNRSAKeychain.swift
@@ -190,9 +190,9 @@ class RNRSAKeychain: NSObject {
     @objc
     func verify(_ signature: String, withMessage: String, keyTag: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
         let rsa_ec = RSAECNative(keyTag: keyTag)
-        let signature = rsa_ec.verify(encodedSignature: signature, withMessage: withMessage, withAlgorithm: "SHA512withRSA")
-        if(signature == nil){
-            reject("not sign it", "error", nil)
+        let verifyResult = rsa_ec.verify(encodedSignature: signature, withMessage: withMessage, withAlgorithm: "SHA512withRSA")
+        if(verifyResult == false){
+            reject("verify failed", "error", nil)
         }else {
             resolve(true)
         }
@@ -201,9 +201,9 @@ class RNRSAKeychain: NSObject {
     @objc
     func verifyWithAlgorithm(_ signature: String, withMessage: String ,keyTag: String, withAlgorithm: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
         let rsa_ec = RSAECNative(keyTag: keyTag)
-        let signature = rsa_ec.verify(encodedSignature: signature, withMessage: withMessage, withAlgorithm: withAlgorithm)
-        if(signature == nil){
-            reject("not sign it", "error", nil)
+        let verifyResult = rsa_ec.verify(encodedSignature: signature, withMessage: withMessage, withAlgorithm: withAlgorithm)
+        if(verifyResult == false){
+            reject("verify failed", "error", nil)
         }else {
             resolve(true)
         }
@@ -212,9 +212,9 @@ class RNRSAKeychain: NSObject {
     @objc
     func verify64(_ signature: String, withMessage: String ,keyTag: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
         let rsa_ec = RSAECNative(keyTag: keyTag)
-        let signature = rsa_ec.verify64(encodedSignature: signature, withMessage: withMessage, withAlgorithm: "SHA512withRSA")
-        if(signature == nil){
-            reject("not sign it", "error", nil)
+        let verifyResult = rsa_ec.verify64(encodedSignature: signature, withMessage: withMessage, withAlgorithm: "SHA512withRSA")
+        if(verifyResult == false){
+            reject("verify failed", "error", nil)
         }else {
             resolve(true)
         }
@@ -223,9 +223,9 @@ class RNRSAKeychain: NSObject {
     @objc
     func verify64WithAlgorithm(_ signature: String, withMessage: String ,keyTag: String, withAlgorithm: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
         let rsa_ec = RSAECNative(keyTag: keyTag)
-        let signature = rsa_ec.verify64(encodedSignature: signature, withMessage: withMessage, withAlgorithm: withAlgorithm)
-        if(signature == nil){
-            reject("not sign it", "error", nil)
+        let verifyResult = rsa_ec.verify64(encodedSignature: signature, withMessage: withMessage, withAlgorithm: withAlgorithm)
+        if(verifyResult == false){
+            reject("verify failed", "error", nil)
         }else {
             resolve(true)
         }

--- a/ios/RSAECNative.swift
+++ b/ios/RSAECNative.swift
@@ -499,7 +499,7 @@ class RSAECNative: NSObject {
     
     private func _verify(signatureBytes: Data, withMessage: Data, withAlgorithm: String) -> Bool? {
         var result = false
-        
+        self.setAlgorithm(algorithm: withAlgorithm)
         // Closures
         let verifier: SecKeyPerformBlock = { publicKey in
             if #available(iOS 10.0, *) {


### PR DESCRIPTION
There was some bugs related to verifying signed messages in iOS.
For me it seems that code was copied from signing function, and therefore comparsions were failing. Also in verifyWithAlgo function the given algorithm was not taken to account