### PR TITLE
Remove jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,6 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
             maven {
                 url "https://maven.fabric.io/public"
             }
@@ -45,7 +44,6 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
@@ -60,3 +58,4 @@ dependencies {
     implementation 'com.madgag.spongycastle:bcpkix-jdk15on:1.56.0.0'
 }
   
+


### PR DESCRIPTION
Remove jcenter to support Gradle 9 and React Native 0.82. `jcenter` has been removed in Gradle 9: https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#removal_of_deprecated_jcenter